### PR TITLE
Rebalances martial arts.

### DIFF
--- a/martialarts.json
+++ b/martialarts.json
@@ -1,0 +1,1093 @@
+[
+    {
+        "type" : "martial_art",
+        "id" : "style_none",
+        "name" : "No style",
+        "description" : "Not a martial art, this is just plain old punching and kicking.",
+        "arm_block" : 1,
+        "leg_block" : 99
+    },{
+        "type" : "martial_art",
+        "id" : "style_kicks",
+        "name" : "Force unarmed",
+        "description" : "Not a martial art, setting this style will prevent weapon attacks and force punches (with free hand) or kicks.",
+        "arm_block" : 1,
+        "leg_block" : 99,
+        "force_unarmed" : true
+    },{
+        "type" : "martial_art",
+        "id" : "style_brawling",
+        "name" : "Brawling",
+        "description" : "You're used to hand-to-creature fighting.  Not stylish or sporting, but it gets the job done.",
+        "arm_block" : -1,
+        "leg_block" : 7,
+        "techniques" : [
+            "tec_brawl_feint",
+            "tec_brawl_power",
+            "tec_brawl_trip",
+            "tec_brawl_counter"
+        ]
+    },{
+        "type" : "martial_art",
+        "id" : "style_karate",
+        "name" : "Karate",
+        "description" : "Karate is a popular martial art, originating from Japan.  It focuses on rapid, precise attacks, blocks, and fluid movement.  A successful hit allows you an extra dodge and two extra blocks on the following round.",
+        "arm_block" : 2,
+        "leg_block" : 99,
+        "onhit_buffs" : [
+            {
+                "id" : "karate_hit_buff",
+                "name" : "Karate Hit",
+                "unarmed_allowed" : true,
+                "min_unarmed" : 0,
+                "buff_duration" : 3,
+                "description" : "+1 Dodges, +2 Blocks",
+                "bonus_dodges" : 1,
+                "bonus_blocks" : 2
+            }
+        ],
+        "techniques" : ["tec_karate_rapid", "tec_karate_precise"]
+    },{
+        "type" : "martial_art",
+        "id" : "style_aikido",
+        "name" : "Aikido",
+        "description" : "Aikido is a Japanese martial art focused on self-defense, while minimizing injury to the attacker.  It uses defensive throws and disarms.  Damage done while using this technique is halved, but pain inflicted is doubled.",
+        "arm_block" : 99,
+        "leg_block" : 99,
+        "static_buffs" : [
+            {
+                "id" : "aikido_half_damage",
+                "name" : "Aikido",
+                "unarmed_allowed" : true,
+                "mult_bonuses" : [["damage", "bash", 0.5]],
+                "min_unarmed" : 0,
+                "buff_duration" : 2,
+                "description" : "Half damage to enemies."
+            }
+        ],
+        "techniques" : [
+            "tec_aikido_feint",
+            "tec_aikido_disarm",
+            "tec_aikido_throw",
+            "tec_aikido_dodgethrow"
+        ]
+    },{
+        "type" : "martial_art",
+        "id" : "style_boxing",
+        "name" : "Boxing",
+        "description" : "Sport of the true gentleman, modern boxing has evolved from the prizefights of the Victorian era.",
+        "arm_block" : 2,
+        "leg_block" : 99,
+           "static_buffs" : [
+            {
+                "id" : "boxing_static",
+                "name" : "Boxing",
+                "description" : "Per increases unarmed power, Str reduces block damage.",
+                "unarmed_allowed" : true,
+                "min_unarmed" : 0,
+                "max_stacks" : 1,
+                "flat_bonuses" : [
+                    ["damage", "bash", "per", 0.4],
+                    ["block", "str", 0.5]
+                ]
+            }
+        ],
+        "onmove_buffs" : [
+            {
+                "id" : "boxing_move_buff",
+                "name" : "Footwork",
+                "description" : "Gain an extra dodge while moving.",
+                "unarmed_allowed" : true,
+                "min_unarmed" : 4,
+                "buff_duration" : 2,
+                "max_stacks" : 2,
+                "bonus_dodges" : 1
+            }
+        ],
+        "ondodge_buffs" : [
+            {
+                "id" : "boxing_counter",
+                "name" : "Counter Chance",
+                "description" : "They're wide open!",
+                "min_unarmed" : 5,
+                "unarmed_allowed" : true,
+                "max_stacks": 2,
+                "buff_duration" : 3,
+                "mult_bonuses" : [["damage", "bash", 1.25]]
+            }
+        ],
+        "techniques" : [
+            "tec_boxing_rapid",
+            "tec_boxing_cross",
+            "tec_boxing_upper",
+            "tec_boxing_counter"
+        ]
+    },{
+        "type" : "martial_art",
+        "id" : "style_judo",
+        "name" : "Judo",
+        "description" : "Judo is a martial art that focuses on grabs and throws, both defensive and offensive.  It also focuses on recovering from throws; while using judo, you will not lose any turns to being thrown or knocked down. Your focus on disrupting an enemies balance means you can attack quickly, but not with the brute force of normal attacks.",
+        "arm_block" : 99,
+        "leg_block" : 99,
+        "mult_bonuses" : [["damage", "bash", 0.7]],
+        "static_buffs" : [
+            {
+                "id" : "judo_recovery",
+                "name" : "Judo",
+                "unarmed_allowed" : true,
+                "min_unarmed" : 0,
+                "buff_duration" : 2,
+                "throw_immune" : true,
+                "description" : "Immune to throws and knockdowns."
+            }
+        ],
+			        "onhit_buffs" : [
+            {
+                "id" : "judo_hit_buff",
+                "name" : "Judo Deflection",
+                "description" : "+Boosts your attack speed",
+                "unarmed_allowed" : true,
+                "min_unarmed" : 1,
+                "buff_duration" : 5,
+                "max_stacks" : 1,
+                "flat_bonuses" : [["movecost", -15]]
+            }
+        ],
+        "techniques" : ["tec_judo_grab", "tec_judo_throw"]
+    },{
+        "type" : "martial_art",
+        "id" : "style_tai_chi",
+        "name" : "Tai Chi",
+        "description" : "Though Tai Chi is often seen as a form of mental and physical exercise, it is a legitimate martial art, focused on self-defense.  Its ability to absorb the force of an attack makes your Perception decrease damage further on a block.",
+        "arm_block" : 1,
+        "leg_block" : 99,
+        "static_buffs" : [
+            {
+                "id" : "tai_chi_block",
+                "name" : "Tai Chi",
+                "unarmed_allowed" : true,
+                "min_unarmed" : 0,
+                "buff_duration" : 2,
+                "flat_bonuses" : [["block", "per", 1.0]],
+                "description" : "+1 Block.  Perception decreases damage when blocking.",
+                "bonus_blocks" : 1
+            }
+        ],
+        "techniques" : ["tec_taichi_disarm", "tec_taichi_precise"]
+    },{
+        "type" : "martial_art",
+        "id" : "style_capoeira",
+        "name" : "Capoeira",
+        "description" : "A dance-like style with its roots in Brazilian slavery, Capoeira is focused on fluid movement and sweeping kicks. Moving will build up momentum, but attacking will use it up. recharge your momentum in between attacks to build up lethal spinning kicks.",
+        "arm_block" : 99,
+        "leg_block" : 99,
+        "onhit_buffs" : [
+            {
+                "id" : "capoeira_hit_buff",
+                "name" : "Capoeira No Momentum",
+                "description" : "Attacking uses up your momentum and reduces damage by 30 temporarily, this stacks up to 3 times",
+                "unarmed_allowed" : true,
+                "min_unarmed" : 1,
+                "buff_duration" : 4,
+                "max_stacks" : 3,
+				"mult_bonuses" : [["damage", "bash", 0.3]]
+            }
+        ],
+        "onmove_buffs" : [
+            {
+                "id" : "capoeira_move_buff",
+                "name" : "Capoeira Momentum",
+                "description" : "+Large bonus damage if you have not lost your momentum",
+                "unarmed_allowed" : true,
+                "min_unarmed" : 2,
+                "buff_duration" : 10,
+                "max_stacks" : 1,
+				"mult_bonuses" : [["damage", "bash", 2.0]]
+                
+            }
+        ],
+        "techniques" : [
+            "tec_capoeira_feint",
+            "SPIN"
+        ]
+    },{
+        "type" : "martial_art",
+        "id" : "style_krav_maga",
+        "name" : "Krav Maga",
+        "description" : "Originating in Israel, Krav Maga is based on taking down an enemy quickly and effectively.  It focuses on applicable attacks rather than showy or complex moves.  Popular among police and armed forces everywhere.",
+        "arm_block" : 2,
+        "leg_block" : 4,
+        "static_buffs" : [
+            {
+                "id" : "krav_maga_static",
+                "name" : "Krav Maga Hand-to-Hand",
+                "unarmed_allowed" : true,
+                "min_unarmed" : 0,
+                "flat_bonuses" : [["damage", "bash", "str", 0.2]],
+                "description" : "Increased unarmed power."
+            },{
+                "id" : "krav_maga_static_edged",
+                "name" : "Krav Maga Edged",
+                "melee_allowed" : true,
+                "min_unarmed" : 0,
+                "mult_bonuses" : [["damage", "stab", 1.2]],
+                "description" : "Increased stabbing damage."
+            }
+        ],
+        "techniques" : [
+            "tec_krav_maga_rapid",
+            "tec_krav_maga_feint",
+            "tec_krav_maga_precise",
+            "tec_krav_maga_disarm",
+            "tec_krav_maga_grab",
+            "tec_krav_maga_break"
+        ],
+        "weapons" : [
+            "tonfa",
+            "tonfa_wood",
+            "shocktonfa_off",
+            "shocktonfa_on"
+        ]
+    },{
+        "type" : "martial_art",
+        "id" : "style_muay_thai",
+        "name" : "Muay Thai",
+        "description" : "Also referred to as the \"Art of 8 Limbs,\" Muay Thai is a popular fighting technique from Thailand that uses powerful strikes.  Your strikes are more powerful with high strength and weaker with low strength, and can momentarily disorient enemies.  As this style focuses on using legs and elbow strikes rather than punches, it does not benefit from using any weapons.",
+        "arm_block" : 3,
+        "leg_block" : 4,
+        "force_unarmed" : true,
+        "static_buffs" : [
+            {
+                "id" : "muay_thai_static",
+                "name" : "Muay Thai",
+                "unarmed_allowed" : true,
+                "flat_bonuses" : [
+                    ["damage", "bash", -5.0],
+                    ["damage", "bash", "str", 0.5]
+                ],
+                "description" : "Attacks scale better with strength."
+            }
+        ],
+        "techniques" : [
+            "tec_muay_thai_elbow",
+            "tec_muay_thai_kick",
+            "tec_muay_thai_knee"
+        ]
+    },{
+        "type" : "martial_art",
+        "id" : "style_ninjutsu",
+        "name" : "Ninjutsu",
+        "description" : "Ninjutsu is a martial art and set of tactics used by ninja in feudal Japan.  It focuses on rapid, precise, silent strikes.  Ninjutsu is almost entirely silent.  It also provides small combat bonuses every time you move.",
+        "arm_block" : 3,
+        "leg_block" : 99,
+        "static_buffs" : [
+            {
+                "id" : "ninjutsu_static",
+                "name" : "Ninjutsu",
+                "unarmed_allowed" : true,
+                "melee_allowed" : true,
+                "quiet" : true,
+                "description" : "Silent melee attacks."
+            }
+        ],
+        "onmove_buffs" : [
+            {
+                "id" : "ninjutsu_momentum",
+                "name" : "Momentum shift",
+                "description" : "Bonus dodges and increased to-hit",
+                "unarmed_allowed" : true,
+                "melee_allowed" : true,
+                "buff_duration" : 2,
+                "max_stacks" : 1,
+                "bonus_dodges" : 1,
+                "flat_bonuses" : [["hit", "dex", 0.17]]
+            }
+        ],
+        "techniques" : ["tec_ninjutsu_precise"]
+    },{
+        "type" : "martial_art",
+        "id" : "style_taekwondo",
+        "name" : "Taekwondo",
+        "description" : "Taekwondo is the national sport of Korea, and was used by the South Korean army in the 20th century.  Focused on kicks and so it does not benefit from wielded weapons.  It also includes strength training; your blocks absorb extra damage the stronger you are.",
+        "arm_block" : 2,
+        "leg_block" : 3,
+        "force_unarmed" : true,
+        "static_buffs" : [
+            {
+                "id" : "taekwondo_static",
+                "name" : "Taekwondo",
+                "unarmed_allowed" : true,
+                "flat_bonuses" : [["block", "str", 0.5]],
+                "description" : "Strength decreases damage when blocking."
+            }
+        ],
+        "techniques" : [
+            "tec_taekwondo_precise",
+            "tec_taekwondo_push",
+            "tec_taekwondo_sweep"
+        ]
+    },{
+        "type" : "martial_art",
+        "id" : "style_biojutsu",
+        "name" : "Bionic Combatives",
+        "description": "A modern combat style for the post-modern human.  Bionic Combatives combines integrated weaponry, armor and augments into an consolidated fighting discipline.",
+        "arm_block" : 99,
+        "leg_block" : 99,
+        "arm_block_with_bio_armor_arms" : true,
+        "leg_block_with_bio_armor_legs" : true,
+        "static_buffs" : [
+            {
+                "id" : "biojutsu_static",
+                "name" : "Biojutsu",
+                "unarmed_allowed" : true,
+                "melee_allowed" : true,
+                "min_unarmed" : 2,
+                "description" : "+1 Blocks",
+                "bonus_blocks" : 1
+            }
+        ],
+        "techniques" : [
+            "tec_biojutsu_counter",
+            "tec_biojutsu_rapid_unarmed",
+            "tec_biojutsu_rapid_armed",
+            "tec_biojutsu_impale",
+            "tec_biojutsu_sweep",
+            "tec_biojutsu_wide"
+        ],
+        "weapons" : [
+            "bio_claws_weapon",
+            "bio_blade_weapon"
+        ]
+    },{
+        "type" : "martial_art",
+        "id" : "style_zui_quan",
+        "name" : "Zui Quan",
+        "description": "AKA \"drunken boxing,\" Zui Quan imitates the movement of a drunk to confuse the enemy, giving you a passive dodge bonus based on your intelligence.  The turn after you attack, you may dodge 3 extra attacks without penalty, and successfully dodging an attack gives you bonus damage and to-hit based on your intelligence.",
+        "arm_block" : 99,
+        "leg_block" : 99,
+        "static_buffs" : [
+            {
+                "id" : "zuiquan_static",
+                "name" : "Zui Quan",
+                "description" : "Intelligence increases dodging ability",
+                "unarmed_allowed" : true,
+                "flat_bonuses" : [["dodge", "int", 0.12]]
+            }
+        ],
+        "onattack_buffs" : [
+            {
+                "id" : "zuiquan_attack_buff",
+                "name" : "Drunken Dodging",
+                "description" : "Unlimited dodges after attacking",
+                "buff_duration" : 4,
+                "unarmed_allowed" : true,
+                "bonus_dodges" : 3
+            }
+        ],
+        "ondodge_buffs" : [
+            {
+                "id" : "zuiquan_dodge_buff",
+                "name" : "Counter Strike",
+                "description" : "Extra damage and to-hit after successful dodge",
+                "unarmed_allowed" : true,
+                "max_stacks": 1,
+                "flat_bonuses" : [
+                    ["damage", "bash", "int", 0.5],
+                    ["hit", "int", 0.2]
+                ]
+            }
+        ],
+        "techniques" : [
+            "tec_zuiquan_feint",
+            "tec_zuiquan_counter"
+        ]
+    },{
+        "type" : "martial_art",
+        "id" : "style_silat",
+        "name" : "Silat",
+        "description": "Pentjak Silat, of Indonesian origin, is a fighting style that covers the use of short blades and bludgeons.  Fighters stay low and mobile to avoid attacks, then unleash deadly critical hits.",
+        "arm_block" : 99,
+        "leg_block" : 99,
+        "static_buffs" : [
+            {
+                "id" : "silat_buff",
+                "name" : "Silat Stance",
+                "description" : "+1 dodge",
+                "unarmed_allowed" : true,
+                "melee_allowed" : true,
+                "bonus_dodges" : 1
+            }
+        ],
+        "ondodge_buffs" : [
+            {
+                "id" : "silat_dodge_buff",
+                "name" : "Silat Counter",
+                "description" : "Extra to-hit after successful dodge",
+                "unarmed_allowed" : true,
+                "melee_allowed" : true,
+                "buff_duration" : 3,
+                "max_stacks": 4,
+                "flat_bonuses" : [["hit", "dex", 0.4]]
+            }
+        ],
+        "techniques" : [
+            "tec_silat_hamstring",
+            "tec_silat_precise",
+            "tec_silat_brutal",
+            "tec_silat_dirty"
+        ],
+        "weapons" : [
+            "baton-extended",
+            "bio_blade_weapon",
+            "bowling_pin",
+            "cudgel",
+            "diveknife",
+            "firemachete_off",
+            "firemachete_on",
+            "glaive",
+            "golf_club",
+            "hockey_stick",
+            "i_staff",
+            "javelin",
+            "javelin_iron",
+            "knife_combat",
+            "knife_hunting",
+            "knife_trench",
+            "kris",
+            "machete",
+            "makeshift_halberd",
+            "makeshift_knife",
+            "makeshift_machete",
+            "naginata",
+            "pipe",
+            "pointy_stick",
+            "pool_cue",
+            "PR24-extended",
+            "primitive_knife",
+            "q_staff",
+            "rebar",
+            "scimitar",
+            "scythe",
+            "scythe_war",
+            "shock_staff",
+            "shocktonfa_off",
+            "shocktonfa_on",
+            "sickle",
+            "shishkebab_off",
+            "shishkebab_on",
+            "spear_knife",
+            "spear_rebar",
+            "spear_pipe",
+            "spear_steel",
+            "spear_survivor",
+            "spear_wood",
+            "spear_homemade_halfpike",
+            "stick",
+            "survivor_machete",
+            "tanto",
+            "tonfa",
+            "tonfa_wood",
+            "kukri",
+            "knife_rambo",
+            "knife_rm42",
+            "switchblade",
+            "l-stick",
+            "l-stick_on"
+        ]
+    },{
+        "type" : "martial_art",
+        "id" : "style_fencing",
+        "name" : "Fencing",
+        "description": "The noble art of fencing is taught with flexible competition blades, but the techniques are derived from (and applicable to) more functional examples.  Skilled fencers can take advantage of advances and retreats to deliver accurate strikes.",
+        "arm_block" : 99,
+        "leg_block" : 99,
+        "onmove_buffs" : [
+            {
+                "id" : "fencing_move_buff",
+                "name" : "Fencing Footwork",
+                "description" : "+2 stab and +1 acc per stack",
+                "min_melee" : 2,
+                "buff_duration" : 2,
+                "max_stacks" : 2,
+                "flat_bonuses" : [
+                    ["damage", "stab", 2.0],
+                    ["hit", 1.0]
+                ]
+            }
+        ],
+        "techniques" : [
+            "tec_feint",
+            "tec_fencing_lunge",
+            "tec_fencing_stop_thrust",
+            "tec_fencing_thrust"
+        ],
+        "weapons" : [
+            "broadsword",
+            "broadfire_off",
+            "broadfire_on",
+            "rapier",
+            "cavalry_sabre",
+            "fencing_foil",
+            "fencing_sabre",
+            "fencing_epee",
+            "umbrella",
+            "cane",
+            "cudgel"
+        ]
+    },{
+        "type" : "martial_art",
+        "id" : "style_niten",
+        "name" : "Niten Ichi-Ryu",
+        "description" : "Niten Ichi-Ryu is an ancient school of combat, transmitting a style of classical Japanese swordsmanship conceived by the warrior Miyamoto Musashi.",
+        "arm_block" : 99,
+        "leg_block" : 99,
+            "static_buffs" : [
+            {
+                "id": "niten_stationary_buff",
+                "name" : "Niten Ichi-Ryu",
+                "description" : "Perception increases dodging and damage.",
+                "min_melee" : 2,
+                "flat_bonuses" : [
+                    ["damage", "cut", "per", 0.5],
+                    ["damage", "bash", "per", 0.5],
+                    ["dodge", "per", 0.5]
+                ]
+            }
+        ],
+        "onmove_buffs" : [
+            {
+                "id" : "niten_move_buff",
+                "name" : "Blocking",
+                "description" : "You forgo dodging on the move, but gain more blocks.",
+                "min_melee" : 2,
+                "max_stacks" : 1,
+                "buff_duration" : 2,
+                "flat_bonuses" : [["dodge", -10.0]],
+                "bonus_dodges" : -1,
+                "bonus_blocks" : 2
+            }
+        ],
+        "onhit_buffs" : [
+            {
+                "id" : "niten_hit_buff",
+                "name" : "Blocking",
+                "description" : "You forgo dodging on the offensive, but gain more blocks.",
+                "min_melee" : 2,
+                "max_stacks" : 1,
+                "buff_duration" : 2,
+                "flat_bonuses" : [["dodge", -10.0]],
+                "bonus_dodges" : -1,
+                "bonus_blocks" : 2
+            }
+        ],
+        "ondodge_buffs" : [
+            {
+                "id" : "niten_set-up",
+                "name" : "In-One Timing Set-Up",
+                "description" : "You found a gap in the enemy's defense!",
+                "min_melee" : 4,
+                "buff_duration" : 2,
+                "max_stacks" : 1
+            }
+        ],
+        "techniques" : [
+            "niten_water_cut",
+            "niten_red_leaf",
+            "niten_stone_cut",
+            "niten_timing_attack",
+            "niten_feint"
+        ],
+        "weapons" : [
+            "katana",
+            "firekatana_off",
+            "firekatana_on",
+            "bokken",
+            "wakizashi",
+            "nodachi"
+        ]
+    },{
+        "type" : "martial_art",
+        "id" : "style_eskrima",
+        "name" : "Eskrima",
+        "description": "Eskrima, also known as Kali, is a Filipino martial art.  It emphasizes rapid strikes with knife and baton weapons, along with a variety of improvised substitutes.",
+        "arm_block" : 99,
+        "leg_block" : 99,
+        "static_buffs" : [
+            {
+                "id" : "eskrima_bash",
+                "name" : "Eskrima Bashing",
+                "melee_allowed" : true,
+                "min_melee" : 1,
+                "mult_bonuses" : [["damage", "bash", 1.2]],
+                "description" : "Increased bashing damage."
+            }
+        ],
+        "onhit_buffs" : [
+            {
+                "id" : "eskrima_hit_buff",
+                "name" : "Eskrima Combination",
+                "description" : "Combination",
+                "melee_allowed" : true,
+                "min_melee" : 2,
+                "buff_duration" : 3,
+                "max_stacks" : 1,
+                "mult_bonuses" : [
+                    ["damage", "bash", 1.1],
+                    ["damage", "cut", 1.1],
+                    ["damage", "stab", 1.1]
+                ]
+            }
+        ],
+        "techniques" : [
+            "tec_eskrima_round",
+            "tec_eskrima_fan",
+            "tec_eskrima_snap",
+            "tec_eskrima_puno",
+            "tec_eskrima_kick",
+            "tec_eskrima_combination"
+        ],
+        "weapons" : [
+            "2x4",
+            "baton-extended",
+            "bee_sting",
+            "bio_blade_weapon",
+            "bowling_pin",
+            "cane",
+            "cudgel",
+            "cu_pipe",
+            "diveknife",
+            "fighter_sting",
+            "firemachete_off",
+            "firemachete_on",
+            "glass_shiv",
+            "hammer",
+            "knife_combat",
+            "knife_hunting",
+            "knife_trench",
+            "machete",
+            "survivor_machete",
+            "makeshift_knife",
+            "makeshift_machete",
+            "pipe",
+            "pockknife",
+            "pool_cue",
+            "PR24-extended",
+            "primitive_knife",
+            "primitive_hammer",
+            "punch_dagger",
+            "scissors",
+            "screwdriver",
+            "sharp_toothbrush",
+            "shishkebab_off",
+            "shishkebab_on",
+            "shocktonfa_off",
+            "shocktonfa_on",
+            "stick",
+            "switchblade",
+            "tanto",
+            "tonfa",
+            "tonfa_wood",
+            "umbrella",
+            "wasp_sting",
+            "wrench",
+            "kukri",
+            "knife_rambo",
+            "knife_rm42",
+            "l-stick",
+            "l-stick_on"
+        ]
+    },{
+        "type" : "martial_art",
+        "id" : "style_crane",
+        "name" : "Crane Kung Fu",
+        "description": "One of the five Shaolin animal styles.  The Crane uses intricate hand techniques and jumping dodges.  Dexterity determines the majority of your damage, rather than Strength; you also receive a dodge bonus the turn after moving a tile.",
+        "arm_block" : 3,
+        "leg_block" : 99,
+        "static_buffs" : [
+            {
+                "id" : "crane_static",
+                "name" : "Crane's Precision",
+                "description" : "Damage bonus from dexterity at the cost of damage from strength.",
+                "unarmed_allowed" : true,
+                "flat_bonuses" : [
+                    ["damage", "bash", "dex", 0.8],
+                    ["damage", "bash", "str", -0.2]
+                ]
+            }
+        ],
+        "onmove_buffs" : [
+            {
+                "id" : "crane_move_buff",
+                "name" : "Crane's Flight",
+                "description" : "+2 Dodge",
+                "unarmed_allowed" : true,
+                "min_unarmed" : 2,
+                "buff_duration" : 2,
+                "flat_bonuses" : [["dodge", 2.0]]
+            }
+        ],
+        "techniques" : [
+            "tec_crane_feint",
+            "tec_crane_break",
+            "tec_crane_precise"
+        ]
+    },{
+        "type" : "martial_art",
+        "id" : "style_dragon",
+        "name" : "Dragon Kung Fu",
+        "description": "One of the five Shaolin animal styles.  The Dragon uses fluid movements and hard strikes.  Dexterity determines the majority of your damage, rather than Strength, and increases accuracy, moving increases damage and accuracy.",
+        "arm_block" : 2,
+        "leg_block" : 99,
+        "static_buffs" : [
+            {
+                "id" : "dragon_static",
+                "name" : "Dragon Style",
+                "description" : "Bonus damage from intelligence.",
+                "unarmed_allowed" : true,
+                "flat_bonuses" : [
+                    ["damage", "bash", "int", 0.8],
+                    ["damage", "bash", "str", -0.2]
+				]
+            }
+        ],
+        "onmove_buffs" : [
+            {
+                "id" : "dragon_move_buff",
+                "name" : "Dragon's Flight",
+                "description" : "+2 Accuracy & Damage",
+                "unarmed_allowed" : true,
+                "min_unarmed" : 2,
+                "buff_duration" : 2,
+                "flat_bonuses" : [
+                    ["hit", 2.0],
+                    ["damage", "bash", 2]
+                ]
+            }
+        ],
+        "techniques" : [
+            "tec_dragon_grab",
+            "tec_dragon_counter",
+            "tec_dragon_sweep",
+            "tec_dragon_brutal"
+        ]
+    },{
+        "type" : "martial_art",
+        "id" : "style_leopard",
+        "name" : "Leopard Kung Fu",
+        "description": "One of the five Shaolin animal styles.  The Leopard focuses on rapid, strategically planned strikes.  Perception and Intelligence both boost dodging, and moving boosts your accuracy.",
+        "arm_block" : 99,
+        "leg_block" : 99,
+        "static_buffs" : [
+            {
+                "id" : "leopard_static",
+                "name" : "Leopard Strategy",
+                "description" : "Perception and intelligence provide a bonus to dodge.",
+                "unarmed_allowed" : true,
+                "flat_bonuses" : [
+                    ["dodge", "per", 0.15],
+                    ["dodge", "int", 0.15]
+                ]
+            }
+        ],
+        "onmove_buffs" : [
+            {
+                "id" : "leopard_move_buff",
+                "name" : "Leopard's Stalk",
+                "description" : "+2 Accuracy",
+                "unarmed_allowed" : true,
+                "min_unarmed" : 2,
+                "buff_duration" : 2,
+                "flat_bonuses" : [["hit", 2.0]]
+            }
+        ],
+        "techniques" : [
+            "tec_leopard_rapid",
+            "tec_leopard_counter",
+            "tec_leopard_precise"
+        ]
+    },{
+        "type" : "martial_art",
+        "id" : "style_tiger",
+        "name" : "Tiger Kung Fu",
+        "description": "One of the five Shaolin animal styles.  The Tiger focuses on relentless attacks above all else.  Your Strength determines your accuracy, and your attacks do increasing damage as you continue attacking.",
+        "arm_block" : 99,
+        "leg_block" : 99,
+        "static_buffs" : [
+            {
+                "id" : "tiger_static",
+                "name" : "Tiger Strength",
+                "description" : "Strength provides additional damage bonus.",
+                "unarmed_allowed" : true,
+                "flat_bonuses" : [
+                    ["damage", "bash", -5.0],
+                    ["damage", "bash", "str", 0.8]
+				]
+            }
+        ],
+        "onhit_buffs" : [
+            {
+                "id" : "tiger_hit_buff",
+                "name" : "Tiger Fury",
+                "description" : "+3 Bash/atk",
+                "unarmed_allowed" : true,
+                "min_unarmed" : 2,
+                "buff_duration" : 3,
+                "max_stacks" : 8,
+                "flat_bonuses" : [["damage", "bash", 3.0]]
+            }
+        ],
+        "techniques" : [
+            "tec_tiger_grab"
+        ]
+    },{
+        "type" : "martial_art",
+        "id" : "style_snake",
+        "name" : "Snake Kung Fu",
+        "description": "One of the five Shaolin animal styles.  The Snake focuses on sinuous movement and precision strikes.  Your Perception improves your damage.",
+        "arm_block" : 99,
+        "leg_block" : 99,
+        "static_buffs" : [
+            {
+                "id" : "snake_static",
+                "name" : "Snake Sight",
+                "description" : "Perception provides a bonus to damage.",
+                "unarmed_allowed" : true,
+                "flat_bonuses" : [
+                    ["damage", "bash", "per", 0.8],
+                    ["damage", "bash", "str", -0.2]
+				]
+            }
+        ],
+        "techniques" : [
+            "tec_snake_rapid",
+            "tec_snake_feint",
+            "tec_snake_break",
+            "tec_snake_precise"
+        ]
+    },{
+        "type" : "martial_art",
+        "id" : "style_centipede",
+        "name" : "Centipede Kung Fu",
+        "description": "One of the Five Deadly Venoms.  Centipede Style uses an onslaught of rapid strikes.  Each attack you land increases your speed by 4.",
+        "arm_block" : 3,
+        "leg_block" : 99,
+        "onhit_buffs" : [
+            {
+                "id" : "centipede_hit_buff",
+                "name" : "Hundred-Hitter",
+                "description" : "+4 Atk Speed",
+                "unarmed_allowed" : true,
+                "min_unarmed" : 1,
+                "buff_duration" : 3,
+                "max_stacks" : 8,
+                "flat_bonuses" : [["movecost", -4.0]]
+            }
+        ],
+        "techniques" : [
+            "tec_centipede_rapid"
+        ]
+    },{
+        "type" : "martial_art",
+        "id" : "style_scorpion",
+        "name" : "Scorpion Kung Fu",
+        "description": "One of the Five Deadly Venoms.  Scorpion Style is a mysterious art which uses pincer-like hands and a stinger kick.  Critical hits do massive damage and knock your target back.",
+        "arm_block" : 3,
+        "leg_block" : 99,
+        "static_buffs" : [
+            {
+                "id" : "scorpion_static",
+                "name" : "Scorpion Venom",
+                "description" : "+2 bashing damage.",
+                "unarmed_allowed" : true,
+                "flat_bonuses" : [["damage", "bash", 2.0]]
+            }
+        ],
+        "techniques" : [
+            "tec_scorpion_precise",
+            "tec_scorpion_brutal"
+        ]
+    },{
+        "type" : "martial_art",
+        "id" : "style_toad",
+        "name" : "Toad Kung Fu",
+        "description": "One of the Five Deadly Venoms.  Masters of Toad Style can focus themselves against all attacks.  You can meditate by pausing, giving you armor, though you will lose focus when you move.",
+        "arm_block" : 3,
+        "leg_block" : 99,
+        "static_buffs" : [
+            {
+                "id" : "toad_static",
+                "name" : "Toad's Iron Skin",
+                "description" : "Gain up to +6 armor while standing still",
+                "//" : "FWIW, this is twice the amount of armor provided by bionic plating.",
+                "unarmed_allowed" : true,
+                "flat_bonuses" : [
+                    ["armor", "bash", 6.0],
+                    ["armor", "cut", 6.0],
+                    ["armor", "stab", 6.0]
+                ]
+            }
+        ],
+        "onmove_buffs": [
+            {
+                "id" : "toad_armor_dissipate",
+                "name" : "Iron Skin Dissipation",
+                "description" : "Iron Skin softens when you move!",
+                "unarmed_allowed" : true,
+                "min_unarmed" : 0,
+                "buff_duration" : 6,
+                "max_stacks" : 6,
+                "flat_bonuses" : [
+                    ["armor", "bash", -1.0],
+                    ["armor", "cut", -1.0],
+                    ["armor", "stab", -1.0]
+                ]
+            }
+        ],
+        "techniques" : [
+            "tec_toad_grab"
+        ]
+    },{
+        "type" : "martial_art",
+        "id" : "style_lizard",
+        "name" : "Lizard Kung Fu",
+        "description": "One of the Five Deadly Venoms.  Lizard Style focuses on using walls to your advantage.",
+        "arm_block" : 2,
+        "leg_block" : 99,
+        "techniques" : [
+        ]
+    },{
+        "type" : "martial_art",
+        "id" : "style_venom_snake",
+        "name" : "Viper Kung Fu",
+        "description": "A legacy of the Five Deadly Venoms.  Viper Style has a unique three-part combo, which initiates on a dodge, then counters with a stunning chop and the legendary Viper Strike. Currently does nothing until someone codes it in and makes a pull request(yes, you)",
+        "arm_block" : 99,
+        "leg_block" : 99,
+        "static_buffs" : [
+            {
+                "id" : "venom_snake_static",
+                "name" : "Viper Patience",
+                "description" : "+2 Dodge.  Dodging an attack initiates a combo.",
+                "unarmed_allowed" : true,
+                "flat_bonuses" : [["dodge", 2.0]]
+            }
+        ],
+        "ondodge_buffs": [
+            {
+                "id" : "venom_snake_combo_initiate",
+                "name" : "Viper Ambush",
+                "description" : "You've lured 'em in!  Your next attack will be a Viper Bite.",
+                "unarmed_allowed" : true,
+                "min_unarmed" : 0,
+                "buff_duration" : 2,
+                "max_stacks" : 1,
+                "mult_bonuses" : [["damage", "bash", 1.5]],
+                "stun_dur" : 2
+            }
+        ],
+        "onhit_buffs": [
+            {
+                "id" : "venom_snake_combo_continue",
+                "name" : "Viper Lock",
+                "description" : "You bit true!  Your next attack will be the Viper Strike!",
+                "unarmed_allowed" : true,
+                "min_unarmed" : 0,
+                "req_buffs" : [
+                    "venom_snake_combo_initiate"
+                ],
+                "buff_duration" : 2,
+                "max_stacks" : 1,
+                "mult_bonuses" : [["damage", "bash", 3]]
+            }
+        ],
+        "techniques" : [
+            "tec_venom_snake_rapid",
+            "tec_venom_snake_feint",
+            "tec_venom_snake_break",
+            "tec_venom_snake_bite",
+            "tec_venom_snake_strike"
+        ]
+    },{
+        "type" : "martial_art",
+        "id" : "style_debug",
+        "name" : "Debug Mastery",
+        "description": "A secret martial art used only by developers and cheaters.",
+        "arm_block" : 99,
+        "leg_block" : 99,
+        "static_buffs" : [
+            {
+                "id" : "debug_elem_resist",
+                "name" : "Elemental resistance",
+                "description" : "+Strength bash armor, +Dexterity acid armor, +Intelligence electricity armor, +Perception fire armor.",
+                "unarmed_allowed" : true,
+                "strictly_unarmed" : true,
+                "flat_bonuses" : [
+                    ["armor", "bash", "str", 1.0],
+                    ["armor", "cut", "dex", 1.0],
+                    ["armor", "electric", "int", 1.0],
+                    ["armor", "heat", "per", 1.0]
+                ]
+            }
+        ],
+        "techniques" : [
+            "tec_debug_slow",
+            "tec_debug_arpen"
+        ]
+    },{
+        "type" : "martial_art",
+        "id" : "style_sojutsu",
+        "name" : "Sōjutsu",
+        "description": "Sōjutsu, \"The Way of the Spear\", is the Japanese martial art of fighting with a spear.  Sōjutsu focuses on keeping opponents at a distance in order to maintain advantage in combat.",
+        "arm_block" : 99,
+        "leg_block" : 99,
+        "static_buffs" : [
+            {
+                "id" : "sojutsu_static",
+                "name" : "Sōjutsu Stance",
+                "description" : "Bonus block with reach weapons while standing still",
+                "unarmed_allowed" : false,
+                "bonus_blocks" : 1
+            }
+        ],
+        "onmove_buffs": [
+            {
+                "id" : "sojutsu_damage_buff",
+                "name" : "Sōjutsu Rush",
+                "description" : "Increased damage when moving but no bonus block",
+                "unarmed_allowed" : false,
+                "min_melee" : 0,
+                "buff_duration" : 2,
+                "max_stacks" : 1,
+                "bonus_blocks" : -1,
+                "mult_bonuses" : [
+                    ["damage", "cut", 1.1],
+                    ["damage", "stab", 1.1]
+                ]
+            }
+        ],
+        "techniques" : [
+            "tec_sojutsu_push",
+			"tec_sojutsu_trip",
+			"tec_sojutsu_skewer"
+        ],
+        "weapons" : [
+			"glaive",
+			"halberd",
+			"halberd_fake",
+			"naginata",
+			"makeshift_halberd",
+			"pike",
+            "pike_inferior",
+            "pike_fake",
+			"pitchfork",
+			"qiang",
+			"spear_copper",
+			"spear_forked",
+			"spear_homemade_halfpike",
+			"spear_pipe",
+			"spear_rebar",
+			"spear_steel",
+			"spear_survivor",
+			"spear_wood"
+        ]
+    }
+]

--- a/mutations.json
+++ b/mutations.json
@@ -1,0 +1,5827 @@
+[
+    {
+        "type" : "mutation",
+        "id" : "FLEET",
+        "name" : "Fleet-Footed",
+        "points" : 2,
+        "description" : "You can move more quickly than most, resulting in a 15% speed bonus on sure footing.",
+        "starting_trait" : true,
+        "changes_to" : ["FLEET2"],
+        "category" : ["SPIDER", "MOUSE"],
+        "types" : ["RUNNING"]
+    },{
+        "type" : "mutation",
+        "id" : "GOODHEARING",
+        "name" : "Good Hearing",
+        "points" : 1,
+        "description" : "Your hearing is better than average, and you can hear distant sounds more easily.",
+        "starting_trait" : true,
+        "category" : ["ALPHA", "MOUSE"],
+        "cancels" : ["BADHEARING"]
+    },{
+        "type" : "mutation",
+        "id" : "OUTDOORSMAN",
+        "name" : "Outdoorsman",
+        "points" : 1,
+        "description" : "You are accustomed to being exposed to the elements.  This decreases morale penalties for being wet.",
+        "starting_trait" : true,
+        "valid" : false,
+        "wet_protection" : [
+            { "part" : "HEAD", "ignored" : 6 },
+            { "part" : "LEG_L", "ignored" : 8 },
+            { "part" : "LEG_R", "ignored" : 8 },
+            { "part" : "FOOT_L", "ignored" : 2 },
+            { "part" : "FOOT_R", "ignored" : 2 },
+            { "part" : "ARM_L", "ignored" : 8 },
+            { "part" : "ARM_R", "ignored" : 8 },
+            { "part" : "HAND_L", "ignored" : 12 },
+            { "part" : "HAND_R", "ignored" : 12 },
+            { "part" : "TORSO", "ignored" : 10 }
+        ]
+    },{
+        "type" : "mutation",
+        "id" : "PARKOUR",
+        "name" : "Parkour Expert",
+        "points" : 2,
+        "description" : "You're skilled at clearing obstacles; terrain like railings or counters are as easy for you to move on as solid ground.",
+        "starting_trait" : true,
+        "valid" : false,
+        "cancels" : ["BADKNEES"]
+    },{
+        "type" : "mutation",
+        "id" : "GOODCARDIO",
+        "name" : "Indefatigable",
+        "points" : 2,
+        "description" : "Whether due to exercise and good diet, or due to a natural propensity to physical endurance, you tire due to physical exertion much less readily than others.  Your maximum stamina is 25% higher than usual.",
+        "starting_trait" : true,
+        "valid" : false,
+        "cancels" : ["BADCARDIO"],
+        "changes_to" : ["GOODCARDIO2"],
+        "category" : ["FISH", "LUPINE", "MOUSE", "INSECT"]
+    },{
+        "type" : "mutation",
+        "id" : "GOODCARDIO2",
+        "name" : "Hyperactive",
+        "points" : 4,
+        "description" : "Your body's efficiency is like that of a tiny furnace, increasing your maximum stamina by 40%.",
+        "valid" : false,
+        "prereqs" : ["GOODCARDIO"],
+        "cancels" : ["BADCARDIO"],
+        "threshreq" : ["THRESH_MOUSE"],
+        "category" : ["MOUSE"]
+    },{
+        "type" : "mutation",
+        "id" : "QUICK",
+        "name" : "Quick",
+        "points" : 3,
+        "description" : "You're just generally quick!  You get a 10% bonus to action points.",
+        "starting_trait" : true,
+        "category" : ["FISH", "BIRD", "INSECT", "TROGLOBITE", "CHIMERA", "RAPTOR", "MOUSE"]
+    },{
+        "type" : "mutation",
+        "id" : "OPTIMISTIC",
+        "name" : "Optimist",
+        "points" : 2,
+        "description" : "Nothing gets you down!  You savor the joys of life, ignore its hardships, and are generally happier than most people.",
+        "starting_trait" : true,
+        "valid" : false,
+        "cancels" : ["BADTEMPER"]
+    },{
+        "type" : "mutation",
+        "id" : "FASTHEALER",
+        "name" : "Fast Healer",
+        "points" : 2,
+        "description" : "You heal faster when sleeping and will even recover a small amount of HP when not sleeping.",
+        "starting_trait" : true,
+        "types" : ["HEALING"],
+        "changes_to" : ["FASTHEALER2", "REGEN_LIZ"],
+        "category" : ["MEDICAL"],
+        "healing_awake" : 0.2,
+        "healing_resting" : 0.5
+    },{
+        "type" : "mutation",
+        "id" : "LIGHTEATER",
+        "name" : "Light Eater",
+        "points" : 2,
+        "description" : "Your metabolism is a little slower, and you require less food than most.",
+        "starting_trait" : true,
+        "cancels" : ["MET_RAT"],
+        "types" : ["METABOLISM"],
+        "changes_to" : [ "GIZZARD", "COLDBLOOD" ],
+        "category" : ["FISH", "BIRD", "INSECT", "TROGLOBITE"],
+        "metabolism_modifier": -0.333
+    },{
+        "type" : "mutation",
+        "id" : "EASYSLEEPER",
+        "name" : "Accomplished Sleeper",
+        "points" : 1,
+        "description" : "You have always been able to fall asleep easily, even when sleeping in less than ideal circumstances.",
+        "changes_to" : ["EASYSLEEPER2"],
+        "starting_trait" : true,
+        "valid" : false,
+        "cancels" : ["INSOMNIA"],
+        "category" : ["MOUSE", "INSECT"]
+    },{
+        "type" : "mutation",
+        "id" : "EASYSLEEPER2",
+        "name" : "Practiced Sleeper",
+        "points" : 2,
+        "description" : "Your body's demanding energy needs mean you can fall asleep just about anywhere.",
+        "prereqs" : ["MET_RAT"],
+        "cancels" : ["INSOMNIA"],
+        "threshreq" : ["THRESH_MOUSE"],
+        "category" : ["MOUSE"]
+    },{
+        "type" : "mutation",
+        "id" : "PAINRESIST",
+        "name" : "Pain Resistant",
+        "points" : 2,
+        "description" : "You have a high tolerance for pain.",
+        "starting_trait" : true,
+        "valid" : false,
+        "cancels" : ["MORE_PAIN", "MORE_PAIN2", "MORE_PAIN3"],
+        "category" : ["MEDICAL"]
+    },{
+        "type" : "mutation",
+        "id" : "NIGHTVISION",
+        "name" : "Night Vision",
+        "points" : 2,
+        "description" : "You possess natural night vision, and can see further in the dark than most.  Activate to toggle NV-visible areas on or off.",
+        "starting_trait" : true,
+        "changes_to" : ["NIGHTVISION2"],
+        "cancels": ["ELFA_NV", "ELFA_FNV", "FEL_NV", "URSINE_EYE"],
+        "category" : ["BIRD", "CATTLE", "INSECT"],
+        "active" : true,
+        "starts_active" : true
+    },{
+        "type" : "mutation",
+        "id" : "POISRESIST",
+        "name" : "Poison Resistant",
+        "points" : 1,
+        "description" : "Your system is rather tolerant of poisons and toxins, and most will affect you less.",
+        "starting_trait" : true,
+        "leads_to" : ["EATPOISON"],
+        "category" : ["INSECT", "SLIME", "SPIDER", "MEDICAL"]
+    },{
+        "type" : "mutation",
+        "id" : "FASTREADER",
+        "name" : "Fast Reader",
+        "points" : 1,
+        "description" : "You're a quick reader, and can get through books a lot faster than most.",
+        "starting_trait" : true,
+        "valid" : false,
+        "cancels" : ["ILLITERATE", "SLOWREADER"]
+    },{
+        "type" : "mutation",
+        "id" : "TOUGH_FEET",
+        "name" : "Tough Feet",
+        "points" : 1,
+        "description" : "The bottoms of your feet are tough and you are accustomed to going barefoot.  You receive no movement penalty for not wearing shoes.",
+        "starting_trait" : true,
+        "valid" : false
+    },{
+        "type" : "mutation",
+        "id" : "TOUGH",
+        "name" : "Tough",
+        "points" : 2,
+        "description" : "It takes a lot to bring you down!  You get a 20% bonus to all hit points.",
+        "starting_trait" : true,
+        "valid" : false,
+        "cancels" : ["FLIMSY", "FLIMSY2", "FLIMSY3", "GLASSJAW"],
+        "changes_to" : ["TOUGH2"],
+        "social_modifiers" : {
+            "intimidate" : 2
+        },
+        "hp_modifier" : 0.2
+    },{
+        "type" : "mutation",
+        "id" : "TOUGH2",
+        "name" : "Durable",
+        "points" : 3,
+        "description" : "You can shrug off almost anything!  You get a 30% bonus to all hit points.",
+        "valid" : false,
+        "cancels" : ["FLIMSY", "FLIMSY2", "FLIMSY3", "GLASSJAW"],
+        "prereqs" : ["TOUGH"],
+        "changes_to" : ["TOUGH3"],
+        "social_modifiers" : {
+            "intimidate" : 3
+        },
+        "hp_modifier" : 0.3
+    },{
+        "type" : "mutation",
+        "id" : "TOUGH3",
+        "name" : "Unbreakable",
+        "points" : 4,
+        "description" : "Nothing can break you!  You get a 40% bonus to all hit points.",
+        "valid" : false,
+        "cancels" : ["FLIMSY", "FLIMSY2", "FLIMSY3", "GLASSJAW"],
+        "prereqs" : ["TOUGH2"],
+        "social_modifiers" : {
+            "intimidate" : 4
+        },
+        "hp_modifier" : 0.4
+    },{
+        "type" : "mutation",
+        "id" : "THICKSKIN",
+        "name" : "Thick-Skinned",
+        "points" : 1,
+        "description" : "Your skin is tough.  Cutting damage is slightly reduced for you.  Slightly decreases wet penalties.",
+        "starting_trait" : true,
+        "category" : ["LIZARD", "CATTLE", "CHIMERA", "RAPTOR"],
+        "cancels" : ["THINSKIN"],
+        "wet_protection" : [
+            { "part" : "LEG_L", "neutral" : 2 },
+            { "part" : "LEG_R", "neutral" : 2 },
+            { "part" : "ARM_L", "neutral" : 2 },
+            { "part" : "ARM_R", "neutral" : 2 },
+            { "part" : "TORSO", "neutral" : 4 }
+        ],
+        "armor" : [ { "parts" : "ALL", "cut" : 1 } ]
+    },{
+        "type" : "mutation",
+        "id" : "PACKMULE",
+        "name" : "Packmule",
+        "points" : 2,
+        "description" : "You can manage to find space for anything!  You can carry 40% more volume.",
+        "starting_trait" : true,
+        "valid" : false,
+        "cancels" : ["DISORGANIZED"]
+    },{
+        "type" : "mutation",
+        "id" : "STRONGBACK",
+        "name" : "Strong Back",
+        "points" : 2,
+        "description" : "You are capable of carrying far more than someone with similar strength could.  Your maximum weight carried is increased by 35%.",
+        "starting_trait" : true,
+        "valid" : false,
+        "cancels" : ["BADBACK"]
+    },{
+        "type" : "mutation",
+        "id" : "FASTLEARNER",
+        "name" : "Fast Learner",
+        "points" : 3,
+        "description" : "You have a flexible mind, allowing you to learn skills much faster than others.  Note that this only applies to real-world experience, not to skill gain from other sources like books.",
+        "starting_trait" : true,
+        "valid" : false,
+        "cancels" : ["SLOWLEARNER"]
+    },{
+        "type" : "mutation",
+        "id" : "STRONGSTOMACH",
+        "name" : "Strong Stomach",
+        "points" : 1,
+        "description" : "You are less likely to throw up from food poisoning, alcohol, etc.  If you throw up nevertheless, you won't suffer a residual nausea.",
+        "starting_trait" : true,
+        "changes_to" : ["NAUSEA"],
+        "//" : "nope.  This does NOT lead to EATPOISON.  Stomach problems are part of the GI upgrades--one advantage to not having Robust Genetics.",
+        "cancels" : ["WEAKSTOMACH"]
+    },{
+        "type" : "mutation",
+        "id" : "GOODMEMORY",
+        "name" : "Good Memory",
+        "points" : 3,
+        "description" : "You have an exceptional memory, and find it easy to remember things.  Your skills will erode slightly slower than usual, and you can remember more terrain.",
+        "starting_trait" : true,
+        "valid" : false,
+        "cancels" : ["FORGETFUL"]
+    },{
+        "type" : "mutation",
+        "id" : "DEFT",
+        "name" : "Deft",
+        "points" : 1,
+        "description" : "While you're not any better at melee combat, you are better at recovering from a miss, and will be able to attempt another strike faster.",
+        "starting_trait" : true,
+        "category" : ["BIRD", "BEAST", "RAPTOR", "MOUSE"]
+    },{
+        "type" : "mutation",
+        "id" : "DRUNKEN",
+        "name" : "Drunken Master",
+        "points" : 1,
+        "description" : "The ancient arts of drunken brawling come naturally to you!  While under the influence of alcohol, your melee skill will rise considerably, especially unarmed combat.",
+        "starting_trait" : true,
+        "valid" : false,
+        "cancels" : ["LIGHTWEIGHT"]
+    },{
+        "type" : "mutation",
+        "id" : "SPIRITUAL",
+        "name" : "Spiritual",
+        "points" : 1,
+        "description" : "You've always felt that there is more to the world than we can see.  Whether driven by religious beliefs or philosophical interest, you find great inspiration in studying holy texts and experiencing mystical things.",
+        "starting_trait" : true,
+        "social_modifiers" : {
+            "persuade" : 5
+        },
+        "valid" : false
+    },{
+        "type" : "mutation",
+        "id" : "TOLERANCE",
+        "name" : "Substance Tolerance",
+        "points" : 1,
+        "description" : "You can handle intoxicants well.  Their effects clear up more quickly for you.",
+        "starting_trait" : true,
+        "leads_to" : ["ALCMET", "EATPOISON"],
+        "cancels" : ["LIGHTWEIGHT"]
+    },{
+        "type" : "mutation",
+        "id" : "GOURMAND",
+        "name" : "Gourmand",
+        "points" : 2,
+        "description" : "You eat faster, and can eat and drink more, than anyone else!  You also enjoy food more; delicious food is better for your morale, and you don't mind unsavory meals as much.  Activate to skip prompt for overeating.",
+        "starting_trait" : true,
+        "category" : ["MOUSE", "LUPINE"],
+        "valid" : false,
+        "active" : true
+    },
+    {
+        "type" : "mutation",
+        "id" : "LOVES_BOOKS",
+        "name" : "Bookworm",
+        "points" : 1,
+        "description" : "There's nothing quite like the smell of a good book!  Books are more fun (or less boring) for you!",
+        "starting_trait" : true,
+        "valid" : false,
+        "cancels" : ["ILLITERATE","HATES_BOOKS"]
+    },
+    {
+        "type" : "mutation",
+        "id" : "NONADDICTIVE",
+        "name" : "Addiction Resistant",
+        "points" : 1,
+        "description" : "Whether due to a lifetime of exposure or through simple willpower, it's harder for you to become addicted to substances, and easier to rid yourself of these addictions.",
+        "starting_trait" : true,
+        "valid" : false,
+        "cancels" : ["ADDICTIVE"]
+    },{
+        "type" : "mutation",
+        "id" : "ANIMALEMPATH",
+        "name" : "Animal Empathy",
+        "points" : 1,
+        "description" : "Peaceful animals will not run away from you, and even aggressive animals are less likely to attack.  This only applies to natural animals such as woodland creatures.",
+        "starting_trait" : true,
+        "category" : ["BEAST"],
+        "cancels" : ["ANIMALDISCORD"]
+    },{
+        "type" : "mutation",
+        "id" : "TERRIFYING",
+        "name" : "Terrifying",
+        "points" : 1,
+        "description" : "There's something about you that creatures find frightening, and they are more likely to try to flee.",
+        "starting_trait" : true,
+        "category" : ["BEAST", "INSECT", "CHIMERA"],
+        "social_modifiers" : {
+            "intimidate" : 15
+        }
+    },{
+        "type" : "mutation",
+        "id" : "DISRESISTANT",
+        "name" : "Disease Resistant",
+        "points" : 1,
+        "description" : "It's very unlikely that you will catch ambient diseases like a cold or the flu.",
+        "starting_trait" : true,
+        "changes_to" : ["DISIMMUNE"],
+        "category" : ["CATTLE", "RAT", "MEDICAL"]
+    },{
+        "type" : "mutation",
+        "id" : "ADRENALINE",
+        "name" : "High Adrenaline",
+        "points" : 1,
+        "description" : "If you are in a very dangerous situation, you may experience a temporary rush which increases your speed and strength significantly.",
+        "starting_trait" : true,
+        "category" : ["BEAST", "CHIMERA"]
+    },{
+        "type" : "mutation",
+        "id" : "WAKEFUL",
+        "name" : "Less Sleep",
+        "points" : 1,
+        "description" : "You need less sleep than the average person.",
+        "changes_to" : ["WAKEFUL2"],
+        "types" : ["SLEEP"],
+        "starting_trait" : true,
+        "category" : ["ALPHA", "ELFA"],
+        "fatigue_modifier": -0.15
+    },{
+        "type" : "mutation",
+        "id" : "SELFAWARE",
+        "name" : "Self-Aware",
+        "points" : 1,
+        "description" : "You get to see your exact amount of HP remaining and health, instead of only having a vague idea of whether you're in good condition or not.",
+        "starting_trait" : true,
+        "valid" : false,
+        "active" : true,
+        "category" : ["MEDICAL"]
+    },{
+        "type" : "mutation",
+        "id" : "INCONSPICUOUS",
+        "name" : "Inconspicuous",
+        "points" : 1,
+        "description" : "While sleeping or staying still, it is less likely that monsters will wander close to you.",
+        "social_modifiers" : {
+            "lie" : 2
+        },
+        "valid" : false
+    },{
+        "type" : "mutation",
+        "id" : "MASOCHIST",
+        "name" : "Masochist",
+        "points" : 1,
+        "description" : "Although you still suffer the negative effects of pain, it also brings a unique pleasure to you.",
+        "starting_trait" : true,
+        "valid" : false,
+        "changes_to" : ["MASOCHIST_MED", "CENOBITE"]
+    },{
+        "type" : "mutation",
+        "id" : "STIMBOOST",
+        "name": "Stimulant Psychosis",
+        "cancels": ["NONADDICTIVE"],
+        "points" : 2,
+        "mixed_effect" : true,
+        "description" : "You have a unique history with stimulants (like coffee or amphetamines). You can tolerate a lot more of them without overdosing, but if you indulge too much, you start seeing things...",
+        "starting_trait" : true,
+        "valid" : false
+    },{
+        "type" : "mutation",
+        "id" : "STYLISH",
+        "name" : "Stylish",
+        "points" : 2,
+        "description" : "Practicality is far less important than style.  Your morale is improved by wearing fashionable and attractive clothing.",
+        "starting_trait" : true,
+        "valid" : false
+    },{
+        "type" : "mutation",
+        "id" : "LIGHTSTEP",
+        "name" : "Light Step",
+        "points" : 1,
+        "description" : "You make less noise while walking.  You're also less likely to set off traps.",
+        "starting_trait" : true,
+        "category" : ["BIRD", "ELFA", "FELINE"],
+        "cancels" : ["CLUMSY"]
+    },{
+        "type" : "mutation",
+        "id" : "ROBUST",
+        "name" : "Robust Genetics",
+        "points" : 3,
+        "description" : "You have a very strong genetic base.  If you mutate, the odds that the mutation will be beneficial are greatly increased.",
+        "starting_trait" : true,
+		"cancels" : ["CHAOTIC_BAD"],
+        "category" : ["FISH", "SLIME", "ALPHA", "MEDICAL"]
+    },{
+        "type" : "mutation",
+        "id" : "EAGLEEYED", "//" : "Can't change the ID as that breaks save-compatibility.",
+        "name" : "Scout",
+        "points" : 1,
+        "description" : "You're an excellent navigator and your ability to spot distant landmarks is unmatched.  Your sight radius on the overmap extends beyond the normal range.",
+        "valid" : false,
+        "starting_trait" : true,
+        "category" : ["MOUSE"],
+        "cancels" : ["MYOPIC", "UNOBSERVANT"]
+    },{
+        "type" : "mutation",
+        "id" : "UNOBSERVANT",
+        "name" : "Topographagnosia",
+        "points" : -5,
+        "description" : "Focal brain damage has rendered you incapable of recognizing landmarks and orienting yourself in your surroundings, severely crippling your sight radius on the overmap.",
+        "valid" : false,
+        "starting_trait" : true,
+        "cancels" : ["EAGLEEYED"]
+    },{
+        "type" : "mutation",
+        "id" : "CANNIBAL",
+        "name" : "Cannibal",
+        "points" : 1,
+        "description" : "For your whole life you've been forbidden from indulging in your peculiar tastes.  Now the world's ended, and you'll be damned if anyone is going to tell you that you can't eat people.",
+        "starting_trait" : true,
+        "valid" : false,
+        "cancels" : ["VEGETARIAN"],
+        "flags" : ["CANNIBAL"]
+    },{
+        "type" : "mutation",
+        "id" : "PSYCHOPATH",
+        "name" : "Psychopath",
+        "points" : 2,
+        "description" : "You don't experience guilt like others do.  Even when you know your actions are wrong, you just don't care.",
+        "starting_trait" : true,
+        "valid" : false,
+        "social_modifiers" : {
+            "intimidate" : 5
+        },
+        "cancels" : ["PACIFIST"],
+        "flags" : ["CANNIBAL"]
+    },{
+        "type" : "mutation",
+        "id" : "MARTIAL_ARTS",
+        "name" : "Martial Arts Training",
+        "points" : 2,
+        "description" : "You have received some martial arts training at a local dojo.  You start with your choice of Karate, Judo, Aikido, Tai Chi, or Taekwondo.",
+        "starting_trait" : true,
+        "initial_ma_styles" : [ "style_karate", "style_judo", "style_aikido", "style_tai_chi", "style_taekwondo" ],
+        "valid" : false
+    },{
+        "type" : "mutation",
+        "id" : "MARTIAL_ARTS2",
+        "name" : "Self-Defense Classes",
+        "points" : 2,
+        "description" : "You have taken some self-defense classes at a nearby gym.  You start with your choice of Capoeira, Krav Maga, Muay Thai, Ninjutsu, or Zui Quan.",
+        "starting_trait" : true,
+        "initial_ma_styles" : [ "style_krav_maga", "style_muay_thai", "style_ninjutsu",  "style_capoeira", "style_zui_quan" ],
+        "valid" : false
+    },{
+        "type" : "mutation",
+        "id": "MARTIAL_ARTS3",
+        "name": "Shaolin Adept",
+        "points": 2,
+        "description": "You have studied the arts of the Shaolin monks.  You start with one of the five animal fighting styles: Tiger, Crane, Leopard, Snake, or Dragon.",
+        "starting_trait" : true,
+        "initial_ma_styles" : [ "style_tiger", "style_crane", "style_leopard", "style_snake", "style_dragon" ],
+        "valid" : false
+    },{
+        "type" : "mutation",
+        "id": "MARTIAL_ARTS4",
+        "name": "Venom Mob Protege",
+        "points": 2,
+        "description": "You are a pupil of the Venom Clan.  You start with one of the five deadly venoms: Centipede, Viper, Scorpion, Lizard, or Toad. This has been obsoleted but is still functional",
+        "starting_trait" : false,
+        "initial_ma_styles" : [ "style_centipede", "style_venom_snake", "style_scorpion", "style_lizard", "style_toad" ],
+        "valid" : false
+    },{
+        "type" : "mutation",
+        "id": "MARTIAL_ARTS5",
+        "name": "Melee Weapon Training",
+        "points": 3,
+        "description": "You have practiced fighting with weapons.  You start with your choice of Eskrima, Fencing, Pentjak Silat, Niten Ichi-Ryu, or Sōjutsu.",
+        "starting_trait" : true,
+        "initial_ma_styles" : [ "style_eskrima", "style_fencing", "style_silat", "style_niten", "style_sojutsu" ],
+        "valid" : false
+    },{
+        "type" : "mutation",
+        "id" : "WEAKSCENT",
+        "name" : "Weak Scent",
+        "points" : 1,
+        "description" : "Your scent is quite weak.  Animals that track your scent will do so with more difficulty.",
+        "starting_trait" : true,
+        "category" : ["ALPHA"],
+        "types" : ["SCENT"]
+    },{
+        "type" : "mutation",
+        "id" : "LIAR",
+        "name" : "Skilled Liar",
+        "points" : 1,
+        "description" : "You have no qualms about bending the truth, and have practically no tells.  Telling lies and otherwise bluffing will be much easier for you.",
+        "starting_trait" : true,
+        "cancels" : ["TRUTHTELLER"],
+        "social_modifiers" : {
+            "lie" : 40
+        }
+    },{
+        "type" : "mutation",
+        "id" : "PRETTY",
+        "name" : "Pretty",
+        "points" : 1,
+        "ugliness" : -2,
+        "description" : "You are a sight to behold.  NPCs who care about such things will react more kindly to you.",
+        "starting_trait" : true,
+        "category" : ["ALPHA", "FELINE", "LUPINE"],
+        "cancels" : ["UGLY", "DEFORMED", "DEFORMED2", "DEFORMED3"],
+        "changes_to" : ["BEAUTIFUL"]
+    },{
+        "type" : "mutation",
+        "id" : "BADKNEES",
+        "name" : "Bad Knees",
+        "points" : -1,
+        "description" : "Whether due to injury or age, your knees aren't particularly strong or flexible.  Moving over rough terrain will slow you down more than normal.",
+        "starting_trait" : true,
+        "valid" : false,
+        "cancels" : ["PARKOUR"]
+    },{
+        "type" : "mutation",
+        "id" : "BADCARDIO",
+        "name" : "Languorous",
+        "points" : -2,
+        "description" : "Whether due to lack of exercise and poor diet, or due to a natural disinclination to physical endurance, you tire due to physical exertion much more readily than others.  Your maximum stamina is 25% lower than usual.",
+        "starting_trait" : true,
+        "valid" : false,
+        "cancels" : ["GOODCARDIO"]
+    },{
+        "type" : "mutation",
+        "id" : "MYOPIC",
+        "name" : "Near-Sighted",
+        "points" : -2,
+        "description" : "Without glasses, your seeing radius is severely reduced!  However, you are guaranteed to start with a pair of glasses.",
+        "starting_trait" : true,
+        "cancels" : ["URSINE_EYE", "EAGLEEYED"],
+        "category" : ["BEAST", "TROGLOBITE"]
+    },{
+        "type" : "mutation",
+        "id" : "SLOWHEALER",
+        "name" : "Slow Healer",
+        "points" : -2,
+        "description" : "You heal a little slower than most; sleeping will heal less HP.",
+        "starting_trait" : true,
+        "types" : ["HEALING"],
+        "healing_resting" : -0.25
+    },{
+        "type" : "mutation",
+        "id" : "SLOWHEALER2",
+        "name" : "Poor Healer",
+        "points" : -4,
+        "description" : "Your health recovery through sleeping is severely impaired and causes you to recover only a third of usual HP.",
+        "starting_trait" : true,
+        "valid": false,
+        "purifiable": false,
+        "types" : ["HEALING"],
+        "healing_resting" : -0.66
+    },{
+        "type" : "mutation",
+        "id" : "SLOWHEALER3",
+        "name" : "Imperceptive Healer",
+        "points" : -8,
+        "description" : "You recover barely any health through sleeping - it will heal only one tenth of usual HP.",
+        "starting_trait" : true,
+        "valid": false,
+        "purifiable": false,
+        "types" : ["HEALING"],
+        "healing_resting" : -0.9
+    },{
+        "type" : "mutation",
+        "id" : "HYPEROPIC",
+        "name" : "Far-Sighted",
+        "points" : -2,
+        "description" : "Without reading glasses, you are unable to read anything, and take penalties on melee accuracy and electronics/tailoring crafting.  However, you are guaranteed to start with a pair of reading glasses.",
+        "starting_trait" : true,
+        "valid" : false
+    },{
+        "type" : "mutation",
+        "id" : "HEAVYSLEEPER",
+        "name" : "Heavy Sleeper",
+        "points" : -1,
+        "description" : "You're quite the heavy sleeper.  Noises are unlikely to wake you up.",
+        "changes_to" : ["HEAVYSLEEPER2"],
+        "starting_trait" : true,
+        "category" : ["INSECT", "PLANT", "MEDICAL", "LUPINE"]
+    },{
+        "type" : "mutation",
+        "id" : "SLEEPY",
+        "name" : "Sleepy",
+        "points" : -1,
+        "description" : "You need sleep more often, but still spend most of your time awake.",
+        "changes_to" : ["SLEEPY2", "MET_RAT"],
+        "starting_trait" : true,
+        "types" : ["SLEEP"],
+        "category" : ["BEAST", "CHIMERA", "MOUSE"],
+        "fatigue_modifier": 0.333,
+        "fatigue_regen_modifier": 0.333
+    },{
+        "type" : "mutation",
+        "id" : "ASTHMA",
+        "name" : "Asthmatic",
+        "points" : -4,
+        "description" : "You will occasionally need to use an inhaler, or else suffer severe physical limitations.  However, you are guaranteed to start with an inhaler.",
+        "social_modifiers" : {
+            "intimidate" : -2
+        },
+        "starting_trait" : true,
+        "valid" : false
+    },{
+        "type" : "mutation",
+        "id" : "BADBACK",
+        "name" : "Bad Back",
+        "points" : -3,
+        "description" : "You simply cannot carry as much as people with a similar strength could.  Your maximum weight carried is reduced by 35%.",
+        "starting_trait" : true,
+        "category" : ["BIRD", "ELFA"],
+        "cancels" : ["STRONGBACK"]
+    },{
+        "type" : "mutation",
+        "id" : "BADTEMPER",
+        "name" : "Bad Temper",
+        "points" : -2,
+        "description" : "Things just keep getting you down.  You tend to be unhappy, and it takes some doing to cheer you up.",
+        "starting_trait" : true,
+        "cancels" : ["OPTIMISTIC"],
+        "category" : ["URSINE", "LIZARD", "CHIMERA"]
+    },{
+        "type" : "mutation",
+        "id" : "DISORGANIZED",
+        "name" : "Disorganized",
+        "points" : -3,
+        "description" : "You are terrible at organizing and storing your possessions.  You can carry 40% less volume.",
+        "starting_trait" : true,
+        "valid" : false,
+        "cancels" : ["PACKMULE"]
+    },{
+        "type" : "mutation",
+        "id" : "ILLITERATE",
+        "name" : "Illiterate",
+        "points" : -6,
+        "description" : "You never learned to read!  Books and computers are off-limits to you.",
+        "starting_trait" : true,
+        "valid" : false,
+        "cancels" : ["FASTREADER", "SLOWREADER", "PROF_DICEMASTER", "LOVES_BOOKS", "HATES_BOOKS"]
+    },{
+        "type" : "mutation",
+        "id" : "BADHEARING",
+        "name" : "Poor Hearing",
+        "points" : -2,
+        "description" : "Your hearing is poor, and you may not hear quiet or far-off noises.",
+        "starting_trait" : true,
+        "category" : ["PLANT"],
+        "cancels" : ["GOODHEARING"]
+    },{
+        "type" : "mutation",
+        "id" : "SLOWLEARNER",
+        "name" : "Slow Learner",
+        "points" : -3,
+        "description" : "You are slow to grasp new ideas and thus learn things more slowly than others.  Note that this only applies to real-world experience, not to skill gain from other sources like books.",
+        "starting_trait" : true,
+        "valid" : false,
+        "cancels" : ["FASTLEARNER"]
+    },{
+        "type" : "mutation",
+        "id" : "INSOMNIA",
+        "name" : "Insomniac",
+        "points" : -2,
+        "description" : "You have a hard time falling asleep, even under the best circumstances!",
+        "starting_trait" : true,
+        "valid" : false,
+        "category" : ["MEDICAL"],
+        "cancels" : ["EASYSLEEPER"]
+    },{
+        "type" : "mutation",
+        "id" : "VEGETARIAN",
+        "name" : "Meat Intolerance",
+        "points" : -2,
+        "description" : "You have problems with eating meat.  It's possible for you to eat it, but you will suffer morale penalties due to nausea.",
+        "starting_trait" : true,
+        "//" : "Intolerances are presumed a psychological issue unless stated otherwise, and cancelled by digestive mutations, which force the issue.",
+        "valid" : false,
+        "cancels" : ["CANNIBAL", "MEATARIAN", "ANTIFRUIT"]
+    },{
+        "type" : "mutation",
+        "id" : "THINSKIN",
+        "name" : "Thin-Skinned",
+        "points" : -1,
+        "description" : "Your skin is fragile.  Cutting damage is slightly increased for you.",
+        "starting_trait" : true,
+        "cancels" : ["THICKSKIN"],
+        "armor" : [ { "parts" : "ALL", "cut" : -1 } ]
+    },{
+        "type" : "mutation",
+        "id" : "MEATARIAN",
+        "name" : "Hates Vegetables",
+        "points" : -2,
+        "description" : "You, like many children, hated eating your vegetables; however, you didn't outgrow it.  It's possible for you to eat them, but you will suffer morale penalties due to nausea.",
+        "starting_trait" : true,
+        "valid" : false,
+        "cancels" : ["VEGETARIAN"]
+    },
+    {
+        "type" : "mutation",
+        "id" : "HATES_BOOKS",
+        "name" : "Hates Books",
+        "points" : -1,
+        "description" : "Reading is for nerds!  Boring books are more boring, and you can't have fun by reading books.",
+        "starting_trait" : true,
+        "valid" : false,
+        "cancels" : ["ILLITERATE","LOVES_BOOKS"]
+    },
+    {
+        "type" : "mutation",
+        "id" : "ANTIFRUIT",
+        "name" : "Hates Fruit",
+        "points" : -3,
+        "description" : "You despise eating fruits.  It's possible for you to eat them, but you will suffer morale penalties due to nausea.",
+        "starting_trait" : true,
+        "valid" : false,
+        "cancels" : ["VEGETARIAN"]
+    },{
+        "type" : "mutation",
+        "id" : "LACTOSE",
+        "name" : "Lactose Intolerance",
+        "points" : -1,
+        "//" : "Actual digestive issue, on even footing with the -vore mutations.",
+        "description" : "You, like 75 percent of the world, cannot tolerate milk or milk-based products.  It's possible for you to eat them, but you will suffer morale penalties due to nausea.",
+        "starting_trait" : true
+    },{
+        "type" : "mutation",
+        "id" : "ANTIJUNK",
+        "name" : "Junkfood Intolerance",
+        "points" : -1,
+        "description" : "Something in those heavily processed foods doesn't agree with you.  It's possible for you to eat them, but you will suffer morale penalties due to nausea.",
+        "starting_trait" : true,
+        "cancels" : ["PROJUNK"],
+        "category" : ["BEAST", "RAPTOR", "ALPHA"]
+    },{
+        "type" : "mutation",
+        "id" : "ANTIWHEAT",
+        "name" : "Grain Intolerance",
+        "points" : -2,
+        "//" : "Actual digestive issue, on even footing with the -vore mutations.",
+        "description" : "You have a rare allergy that prevents you from eating most types of grains such as wheat or oats.  It's possible for you to eat them, but you will suffer morale penalties due to nausea.",
+        "starting_trait" : true
+    },{
+        "type" : "mutation",
+        "id" : "PROJUNK",
+        "name" : "Sweet Tooth",
+        "points" : 1,
+        "description" : "You have a soft spot for processed foods, and gain a morale bonus from eating them.",
+        "cancels" : ["ANTIJUNK"],
+        "changes_to" : ["PROJUNK2"],
+        "category" : ["MOUSE", "INSECT"]
+    },{
+        "type" : "mutation",
+        "id" : "PROJUNK2",
+        "name" : "Sugar-Loving",
+        "points" : 2,
+        "description" : "You *adore* the taste of junk food, and find it preferable to everything else!",
+        "purifiable" : false,
+        "prereqs" : ["PROJUNK"],
+        "cancels" : ["ANTIJUNK"],
+        "threshreq" : ["THRESH_MOUSE"],
+        "category" : ["MOUSE"]
+    },{
+        "type" : "mutation",
+        "id" : "GLASSJAW",
+        "name" : "Glass Jaw",
+        "points" : -2,
+        "description" : "Your head can't take much abuse.  Its maximum HP is 20% lower than usual.",
+        "starting_trait" : true,
+        "social_modifiers" : {
+            "intimidate" : -2
+        },
+        "category" : ["BIRD", "RAPTOR"],
+        "cancels" : ["TOUGH"]
+    },{
+        "type" : "mutation",
+        "id" : "FORGETFUL",
+        "name" : "Forgetful",
+        "points" : -3,
+        "description" : "You have a hard time remembering things.  Your skills will erode slightly faster than usual, and you can remember less terrain.",
+        "social_modifiers" : {
+            "lie" : -5
+        },
+        "starting_trait" : true,
+        "category" : ["BEAST", "MEDICAL", "CHIMERA", "MOUSE", "INSECT"],
+        "cancels" : ["GOODMEMORY"]
+    },{
+        "type" : "mutation",
+        "id" : "LIGHTWEIGHT",
+        "name" : "Lightweight",
+        "points" : -1,
+        "description" : "Alcohol and drugs go straight to your head.  You suffer the negative effects of these for longer.",
+        "starting_trait" : true,
+        "category" : ["MEDICAL"],
+        "cancels" : ["DRUNKEN", "TOLERANCE"]
+    },{
+        "type" : "mutation",
+        "id" : "ADDICTIVE",
+        "name" : "Addictive Personality",
+        "points" : -2,
+        "description" : "It's easier for you to become addicted to substances, and harder to rid yourself of these addictions.",
+        "starting_trait" : true,
+        "valid" : false,
+        "category" : ["MEDICAL", "MOUSE"],
+        "cancels" : ["NONADDICTIVE"]
+    },{
+        "type" : "mutation",
+        "id" : "TRIGGERHAPPY",
+        "name" : "Trigger Happy",
+        "points" : -1,
+        "description" : "On rare occasion, you will go full-auto when you intended to fire a single shot.  This has no effect when firing semi-automatic firearms.",
+        "starting_trait" : true,
+        "valid" : false
+    },{
+        "type" : "mutation",
+        "id" : "SMELLY",
+        "name" : "Strong Scent",
+        "points" : -1,
+        "description" : "Your scent is particularly strong.  It's not offensive to humans, but animals that track your scent will do so more easily.",
+        "starting_trait" : true,
+        "changes_to" : ["SMELLY2"],
+        "types" : ["SCENT"],
+        "category" : ["FELINE", "LUPINE", "MOUSE"]
+    },{
+        "type" : "mutation",
+        "id" : "CHEMIMBALANCE",
+        "name" : "Chemical Imbalance",
+        "points" : -2,
+        "description" : "You suffer from a minor chemical imbalance, whether mental or physical.  Minor changes to your internal chemistry will manifest themselves on occasion, such as hunger, sleepiness, narcotic effects, etc.",
+        "starting_trait" : true,
+        "category" : ["SLIME", "MEDICAL", "CHIMERA", "ELFA"]
+    },{
+        "type" : "mutation",
+        "id" : "ANIMALDISCORD",
+        "name" : "Animal Discord",
+        "points" : -1,
+        "description" : "Most animals don't like you, and aggressive animals are more likely to attack you.  This only applies to natural animals such as woodland creatures.",
+        "starting_trait" : true,
+        "cancels" : ["ANIMALEMPATH"],
+        "changes_to" : ["ANIMALDISCORD2"],
+        "category" : ["LUPINE", "BEAST", "RAPTOR", "INSECT"]
+    },{
+        "type" : "mutation",
+        "id" : "ANIMALDISCORD2",
+        "name" : "Prey Animal",
+        "points" : -3,
+        "description" : "Natural animals like dogs and wolves see you as prey, and are liable to attack you on sight.",
+        "cancels" : ["ANIMALEMPATH"],
+        "prereqs" : ["ANIMALDISCORD"],
+        "category" : ["MOUSE"]
+    },{
+        "type" : "mutation",
+        "id" : "SLOWREADER",
+        "name" : "Slow Reader",
+        "points" : -1,
+        "description" : "You're a slow reader, and it takes you longer to get through books than most.",
+        "starting_trait" : true,
+        "valid" : false,
+        "cancels" : ["ILLITERATE", "FASTREADER"]
+    },{
+        "type" : "mutation",
+        "id" : "SCHIZOPHRENIC",
+        "name" : "Schizophrenic",
+        "points" : -2,
+        "description" : "You will periodically suffer from delusions, ranging from minor effects to full visual hallucinations.  Some of these effects may be controlled through the use of Thorazine.",
+        "starting_trait" : true,
+        "valid" : false,
+        "category" : ["MEDICAL"]
+    },{
+        "type" : "mutation",
+        "id" : "NARCOLEPTIC",
+        "name" : "Narcoleptic",
+        "points" : -3,
+        "description" : "You randomly fall asleep without any reason.",
+        "starting_trait" : true,
+        "valid" : false,
+        "category" : ["MEDICAL"]
+    },{
+        "type" : "mutation",
+        "id" : "CLUMSY",
+        "name" : "Clumsy",
+        "points" : -1,
+        "description" : "You make more noise while walking.  You're also more likely to set off traps.",
+        "starting_trait" : true,
+        "cancels" : ["LIGHTSTEP"]
+    },{
+        "type" : "mutation",
+        "id" : "JITTERY",
+        "name" : "Jittery",
+        "points" : -3,
+        "description" : "During moments of great stress or under the effects of stimulants, you may find your hands shaking uncontrollably, severely reducing your Dexterity.",
+        "starting_trait" : true,
+        "valid" : false,
+        "category" : ["MEDICAL", "MOUSE"]
+    },{
+        "type" : "mutation",
+        "id" : "HOARDER",
+        "name" : "Hoarder",
+        "points" : -4,
+        "description" : "You don't feel right unless you're carrying as much as you can.  You suffer morale penalties for carrying less than maximum volume (weight is ignored).  Xanax can help control this anxiety.",
+        "starting_trait" : true,
+        "valid" : false
+    },{
+        "type" : "mutation",
+        "id" : "SAVANT",
+        "name" : "Savant",
+        "points" : -4,
+        "description" : "You tend to specialize in one skill and be poor at all others.  You advance at half speed in all skills except your best one.  Note that combining this with Fast Learner will come out to a slower rate of learning for all skills.",
+        "starting_trait" : true,
+        "valid" : false
+    },{
+        "type" : "mutation",
+        "id" : "PACIFIST",
+        "name" : "Pacifist",
+        "points" : -4,
+        "description" : "You don't like thinking about violence.  Your combat skills advance much slower than usual, and you feel more guilt about killing.",
+        "starting_trait" : true,
+        "social_modifiers" : {
+            "intimidate" : -10
+        },
+        "valid" : false,
+        "cancels" : ["PSYCHOPATH", "PRED1", "PRED2", "PRED3", "PRED4"]
+    },{
+        "type" : "mutation",
+        "id" : "MOODSWINGS",
+        "name" : "Mood Swings",
+        "points" : -1,
+        "description" : "Your morale will shift up and down at random, often dramatically.",
+        "starting_trait" : true,
+        "valid" : false,
+        "category" : ["MEDICAL"]
+    },{
+        "type" : "mutation",
+        "id" : "SLOWRUNNER",
+        "name" : "Slow Footed",
+        "points" : -3,
+        "description" : "You can't move as fast as most, resulting in a 15% speed penalty on flat ground.",
+        "starting_trait" : true,
+        "types" : ["RUNNING"]
+    },{
+        "type" : "mutation",
+        "id" : "WEAKSTOMACH",
+        "name" : "Weak Stomach",
+        "points" : -1,
+        "description" : "You are more likely to throw up from food poisoning, alcohol, etc.",
+        "starting_trait" : true,
+        "changes_to" : ["NAUSEA"],
+        "cancels" : ["STRONGSTOMACH"]
+    },{
+        "type" : "mutation",
+        "id" : "WOOLALLERGY",
+        "name" : "Wool Allergy",
+        "points" : -1,
+        "description" : "You are badly allergic to wool, and cannot wear any clothing made of the substance.",
+        "starting_trait" : true,
+        "valid" : true
+    },{
+        "type" : "mutation",
+        "id" : "TRUTHTELLER",
+        "name" : "Truth Teller",
+        "points" : -1,
+        "description" : "When you try to tell a lie, you blush, stammer, and get all shifty-eyed.  Telling lies and otherwise bluffing will be much more difficult for you.",
+        "starting_trait" : true,
+        "cancels" : ["LIAR"],
+        "social_modifiers" : {
+            "lie" : -40
+        }
+    },{
+        "type" : "mutation",
+        "id" : "UGLY",
+        "name" : "Ugly",
+        "points" : -1,
+        "ugliness" : 2,
+        "description" : "You're not much to look at.  NPCs who care about such things will react poorly to you.",
+        "starting_trait" : true,
+        "cancels" : ["PRETTY", "BEAUTIFUL", "BEAUTIFUL2", "BEAUTIFUL3"],
+        "changes_to" : ["DEFORMED"],
+        "category": ["RAPTOR", "FELINE", "LUPINE"]
+    },{
+        "type" : "mutation",
+        "id" : "ALBINO",
+        "name" : "Albino",
+        "points" : -1,
+        "description" : "You lack skin pigmentation due to a genetic problem.  You sunburn extremely easily, and typically use an umbrella and sunglasses when going out in the sun.",
+        "starting_trait" : true,
+        "changes_to" : ["SUNBURN"],
+        "category" : ["TROGLOBITE", "MOUSE"]
+    },{
+        "type" : "mutation",
+        "id" : "FLIMSY",
+        "name" : "Flimsy",
+        "points" : -4,
+        "description" : "Your body can't take much abuse.  Its maximum HP is 25% lower than usual and you heal slightly slower.  Stacks with Glass Jaw.",
+        "starting_trait" : true,
+        "valid" : false,
+        "social_modifiers" : {
+            "intimidate" : -2
+        },
+        "cancels" : ["TOUGH", "TOUGH2", "TOUGH3"],
+        "category" : ["MOUSE"],
+        "changes_to" : ["FLIMSY2"],
+        "hp_modifier" : -0.25
+    },{
+        "type" : "mutation",
+        "id" : "FLIMSY2",
+        "name" : "Frail",
+        "points" : -6,
+        "description" : "Your body breaks very easily.  Its maximum HP is 50% lower than usual and you heal slower.  Stacks with Glass Jaw.",
+        "starting_trait" : true,
+        "valid" : false,
+        "social_modifiers" : {
+            "intimidate" : -3
+        },
+        "cancels" : ["TOUGH", "TOUGH2", "TOUGH3"],
+        "prereqs" : ["FLIMSY"],
+        "changes_to" : ["FLIMSY3"],
+        "hp_modifier" : -0.5
+    },{
+        "type" : "mutation",
+        "id" : "FLIMSY3",
+        "name" : "Fragile",
+        "points" : -8,
+        "description" : "Your body is extremely fragile.  Its maximum HP is 75% lower than usual and you heal much slower.  Stacks with Glass Jaw.",
+        "starting_trait" : true,
+        "valid" : false,
+        "social_modifiers" : {
+            "intimidate" : -4
+        },
+        "cancels" : ["TOUGH", "TOUGH2", "TOUGH3"],
+        "prereqs" : ["FLIMSY2"],
+        "hp_modifier" : -0.75
+    },{
+        "type" : "mutation",
+        "id" : "CHAOTIC_BAD",
+        "name" : "Genetic Downward Spiral",
+        "points" : -12,
+        "purifiable" : false,
+        "description" : "The events of the Cataclysm have damaged your DNA beyond repair.  You mutate frequently, and all mutations you receive (from any source) are negative.",
+        "starting_trait" : true,
+		"cancels" : ["ROBUST"],
+        "valid" : false
+    },{
+        "type" : "mutation",
+        "id" : "SKIN_ROUGH",
+        "name" : "Rough Skin",
+        "points" : 0,
+        "visibility" : 2,
+        "ugliness" : 1,
+        "description" : "Your skin is slightly rough.  This has no gameplay effect.",
+        "types" : ["SKIN"],
+        "changes_to" : ["SCALES", "FEATHERS", "LIGHTFUR", "CHITIN", "PLANTSKIN"],
+        "category" : ["LIZARD"]
+    },{
+        "type" : "mutation",
+        "id" : "NIGHTVISION2",
+        "name" : "High Night Vision",
+        "points" : 4,
+        "description" : "You can see incredibly well in the dark!  Activate to toggle NV-visible areas on or off.",
+        "prereqs" : ["NIGHTVISION"],
+        "changes_to" : ["NIGHTVISION3"],
+        "cancels" : ["ELFA_NV", "ELFA_FNV", "FEL_NV", "URSINE_EYE"],
+        "category" : ["FISH", "BEAST", "INSECT", "RAT", "CHIMERA", "LUPINE", "MOUSE"],
+        "active" : true,
+        "starts_active" : true
+    },{
+        "type" : "mutation",
+        "id" : "NIGHTVISION3",
+        "name" : "Full Night Vision",
+        "points" : 6,
+        "description" : "You can see in pitch blackness as if you were wearing night-vision goggles.  Activate to toggle NV-visible areas on or off.",
+        "prereqs" : ["NIGHTVISION2"],
+        "leads_to" : ["INFRARED"],
+        "cancels" : ["ELFA_NV", "ELFA_FNV", "FEL_NV", "URSINE_EYE"],
+        "category" : ["FISH", "TROGLOBITE", "SPIDER"],
+        "active" : true,
+        "starts_active" : true
+    },{
+        "type" : "mutation",
+        "id" : "CEPH_EYES",
+        "name" : "Cephalopod Eyes",
+        "points" : 1,
+        "visibility" : 8,
+        "ugliness" : 5,
+        "description" : "Your eyes still bulge, yet your pupils look different somehow.  Water doesn't seem to cause any trouble at all, though.",
+        "leads_to" : ["CEPH_VISION"],
+        "cancels" : ["BIRD_EYE", "LIZ_EYE", "FEL_EYE", "URSINE_EYE", "COMPOUND_EYES", "ELFAEYES"],
+        "category" : ["CEPHALOPOD"]
+    },{
+        "type" : "mutation",
+        "id" : "CEPH_VISION",
+        "name" : "Cephalopod Vision",
+        "points" : 3,
+        "description" : "Your brain has caught up with your eyes.  You can see much better in the dark, but sunlight seems much brighter now.  Activate to toggle NV-visible areas on or off.",
+        "prereqs" : ["CEPH_EYES"],
+        "cancels" : ["LIZ_IR", "FEL_NV", "NIGHTVISION", "NIGHTVISION2", "NIGHTVISION3", "ELFA_NV", "ELFA_FNV"],
+        "category" : ["CEPHALOPOD"],
+        "active" : true,
+        "starts_active" : true
+    },{
+        "type" : "mutation",
+        "id" : "ELFAEYES",
+        "name" : "Fey Eyes",
+        "points" : 1,
+        "description" : "Your eyes have turned...green.  It's tough to tell the exact shade as it seems to shift.  The effect is ...pleasant.",
+        "leads_to" : ["ELFA_NV"],
+        "valid" : false,
+        "cancels" : ["BIRD_EYE", "LIZ_EYE", "FEL_EYE", "URSINE_EYE", "COMPOUND_EYES"],
+        "category" : ["ELFA"],
+        "social_modifiers" : {
+            "lie" : 5,
+            "persuade" : 5,
+            "intimidate" : -5
+        }
+    },{
+        "type" : "mutation",
+        "id" : "ELFA_NV",
+        "name" : "Fey Vision",
+        "points" : 3,
+        "description" : "The shadows don't seem as dark now.  Activate to toggle NV-visible areas on or off.",
+        "prereqs" : ["ELFAEYES"],
+        "changes_to" : ["ELFA_FNV"],
+        "cancels" : ["LIZ_IR", "FEL_NV", "NIGHTVISION", "NIGHTVISION2", "NIGHTVISION3"],
+        "category" : ["ELFA"],
+        "active" : true,
+        "starts_active" : true
+    },{
+        "type" : "mutation",
+        "id" : "ELFA_FNV",
+        "name" : "Fey Nightsight",
+        "points" : 5,
+        "description" : "You have great low-light vision now, though that doesn't allow you to perform fine tasks such as crafting and reading in darkness.  Activate to toggle NV-visible areas on or off.",
+        "prereqs" : ["ELFA_NV"],
+        "cancels" : ["LIZ_IR", "FEL_NV", "NIGHTVISION", "NIGHTVISION2", "NIGHTVISION3"],
+        "category" : ["ELFA"],
+        "active" : true,
+        "starts_active" : true
+    },{
+        "type" : "mutation",
+        "id" : "FEL_EYE",
+        "name" : "Feline Eyes",
+        "points" : 0,
+        "visibility" : 2,
+        "ugliness" : 1,
+        "description" : "Your eyes have mutated, now having a slitted pupil and glittering in light, much like those of cats.  This is visually striking, but it isn't helping you see at night.",
+        "social_modifiers" : {
+            "lie" : 2,
+            "persuade" : 2
+        },
+        "leads_to" : ["FEL_NV"],
+        "cancels" : ["ELFAEYES", "LIZ_EYE", "BIRD_EYE", "URSINE_EYE", "COMPOUND_EYES"],
+        "category" : ["FELINE", "BEAST"]
+    },{
+        "type" : "mutation",
+        "id" : "FEL_NV",
+        "name" : "Feline Vision",
+        "points" : 4,
+        "description" : "Your optic nerves and brain caught up with your eyes.  Now you can see pretty well at night.  Activate to toggle NV-visible areas on or off.",
+        "prereqs" : ["FEL_EYE"],
+        "cancels" : ["ELFA_NV", "ELFA_FNV", "LIZ_IR", "NIGHTVISION", "NIGHTVISION2", "NIGHTVISION3"],
+        "category" : ["FELINE"],
+        "active" : true,
+        "starts_active" : true
+    },{
+        "type" : "mutation",
+        "id" : "URSINE_EYE",
+        "name" : "Ursine Vision",
+        "points" : 1,
+        "description" : "Your visual processing has shifted: though you can see better in the dark, you're nearsighted in the light.  Maybe glasses would help.  Activate to toggle NV-visible areas on or off.",
+        "cancels" : ["ELFAEYES", "LIZ_EYE", "BIRD_EYE", "FEL_EYE", "COMPOUND_EYES", "NIGHTVISION", "NIGHTVISION2", "NIGHTVISION3", "MYOPIC"],
+        "category" : ["URSINE"],
+        "active" : true,
+        "starts_active" : true
+    },{
+        "type" : "mutation",
+        "id" : "BIRD_EYE",
+        "name" : "Avian Eyes",
+        "points" : 5,
+        "visibility" : 1,
+        "description" : "Your vision has become particularly acute: you suspect you could pick out zombies much farther away.  Perception +4.",
+        "cancels" : ["ELFAEYES", "FEL_EYE", "LIZ_EYE", "URSINE_EYE", "COMPOUND_EYES"],
+        "prereqs" : ["PER_UP"],
+        "threshreq" : ["THRESH_BIRD"],
+        "category" : ["BIRD"]
+    },{
+        "type" : "mutation",
+        "id" : "INFRARED",
+        "name" : "Infrared Vision",
+        "points" : 5,
+        "description" : "Your eyes have mutated to pick up radiation in the infrared spectrum.",
+        "prereqs" : ["NIGHTVISION3"],
+        "cancels" : ["LIZ_IR"],
+        "category" : ["INSECT", "TROGLOBITE", "SPIDER"]
+    },{
+        "type" : "mutation",
+        "id" : "LIZ_EYE",
+        "name" : "Reptilian Eyes",
+        "points" : 0,
+        "visibility" : 2,
+        "ugliness" : 1,
+        "description" : "Your eyes have mutated, with a brilliant iris and slitted pupil similar to that of a lizard.  This is visually striking, but doesn't seem to affect your vision.",
+        "social_modifiers" : {
+            "persuade" : -1,
+            "intimidate" : 1
+        },
+        "leads_to" : ["LIZ_IR"],
+        "cancels" : ["ELFAEYES", "FEL_EYE", "URSINE_EYE", "BIRD_EYE", "COMPOUND_EYES"],
+        "category" : ["LIZARD", "RAPTOR"]
+    },{
+        "type" : "mutation",
+        "id" : "LIZ_IR",
+        "name" : "Reptilian IR",
+        "points" : 5,
+        "description" : "Your optic nerves and brain have mutated to catch up with your eyes, allowing you to see in the infrared spectrum.",
+        "prereqs" : ["LIZ_EYE"],
+        "cancels" : ["ELFA_NV", "ELFA_FNV", "FEL_NV", "INFRARED"],
+        "category" : ["LIZARD", "RAPTOR"]
+    },{
+        "type" : "mutation",
+        "id" : "FASTHEALER2",
+        "name" : "Very Fast Healer",
+        "points" : 4,
+        "description" : "Your flesh regenerates slowly, and you will regain HP even when not sleeping.",
+        "types" : ["HEALING"],
+        "prereqs" : ["FASTHEALER"],
+        "changes_to" : ["REGEN"],
+        "category" : ["PLANT"],
+        "healing_awake" : 0.66,
+        "healing_resting" : 0.5
+    },{
+        "type" : "mutation",
+        "id" : "REGEN",
+        "name" : "Regeneration",
+        "points" : 6,
+        "description" : "Your flesh regenerates from wounds incredibly quickly.",
+        "types" : ["HEALING"],
+        "prereqs" : ["FASTHEALER2"],
+        "category" : ["SLIME", "TROGLOBITE"],
+        "healing_awake" : 2.0,
+        "healing_resting" : 1.5
+    },{
+        "type" : "mutation",
+        "id" : "REGEN_LIZ",
+        "name" : "Reptilian Healing",
+        "points" : 5,
+        "valid" : false,
+        "purifiable" : false,
+        "description" : "Your broken limbs mend themselves without significant difficulty.",
+        "cancels" : ["ROT1", "ROT2", "ROT3"],
+        "prereqs" : ["FASTHEALER"],
+        "threshreq" : ["THRESH_LIZARD"],
+        "category" : ["LIZARD"]
+    },{
+        "type" : "mutation",
+        "id" : "WAKEFUL2",
+        "name" : "Very Little Sleep",
+        "points" : 3,
+        "description" : "You don't sleep often.  But when you do, you need very little of it.",
+        "valid" : false,
+        "types" : ["SLEEP"],
+        "prereqs" : ["WAKEFUL"],
+        "changes_to" : ["WAKEFUL3"],
+        "threshreq" : ["THRESH_ALPHA", "THRESH_ELFA"],
+        "category" : ["ALPHA", "ELFA"],
+        "fatigue_modifier": -0.25
+    },{
+        "type" : "mutation",
+        "id" : "WAKEFUL3",
+        "name" : "Tireless",
+        "points" : 5,
+        "description" : "You defend the realm all night and all day.",
+        "valid" : false,
+        "purifiable" : false,
+        "types" : ["SLEEP"],
+        "prereqs" : ["WAKEFUL2"],
+        "threshreq" : ["THRESH_ELFA"],
+        "category" : ["ELFA"],
+        "fatigue_modifier": -0.5,
+        "fatigue_regen_modifier": 0.5
+    },{
+        "type" : "mutation",
+        "id" : "FANGS",
+        "name" : "Fangs",
+        "points" : 2,
+        "visibility" : 2,
+        "ugliness" : 2,
+        "description" : "Your teeth have grown into two-inch-long fangs, allowing you to make an extra attack when conditions favor it.",
+        "types" : ["TEETH"],
+        "changes_to" : ["SABER_TEETH", "SHARKTEETH"],
+        "category" : ["LIZARD", "FISH", "LUPINE", "FELINE", "CHIMERA"],
+        "attacks" : [
+            {
+                "attack_text_u" : "You sink your fangs into %s",
+                "attack_text_npc" : "%1$s sinks their fangs into %2$s",
+                "blocker_mutations" : [ "MUZZLE", "MUZZLE_LONG", "MUZZLE_RAT" ],
+                "body_part" : "MOUTH",
+                "chance" : 20,
+                "base_damage" : { "damage_type" : "stab", "amount" : 20 }
+            },
+            {
+                "attack_text_u" : "You sink your fangs into %s",
+                "attack_text_npc" : "%1$s sinks their fangs into %2$s",
+                "required_mutations" : [ "MUZZLE" ],
+                "body_part" : "MOUTH",
+                "chance" : 18,
+                "base_damage" : { "damage_type" : "stab", "amount" : 20 }
+            },
+            {
+                "attack_text_u" : "You sink your fangs into %s",
+                "attack_text_npc" : "%1$s sinks their fangs into %2$s",
+                "required_mutations" : [ "MUZZLE_LONG" ],
+                "body_part" : "MOUTH",
+                "chance" : 15,
+                "base_damage" : { "damage_type" : "stab", "amount" : 20 }
+            },
+            {
+                "attack_text_u" : "You sink your fangs into %s",
+                "attack_text_npc" : "%1$s sinks their fangs into %2$s",
+                "required_mutations" : [ "MUZZLE_RAT" ],
+                "body_part" : "MOUTH",
+                "chance" : 19,
+                "base_damage" : { "damage_type" : "stab", "amount" : 20 }
+            }
+        ]
+    },{
+        "type" : "mutation",
+        "id" : "INCISORS",
+        "name" : "Incisors",
+        "points" : 2,
+        "visibility" : 3,
+        "ugliness" : 3,
+        "description" : "Your big teeth have grown in.  Folks had best show some more respect.",
+        "types" : ["TEETH"],
+        "prereqs" : ["MUZZLE_RAT"],
+        "threshreq" : ["THRESH_RAT"],
+        "category" : ["RAT"],
+        "attacks" : {
+            "attack_text_u" : "You bite into %s with your ratlike incisors",
+            "attack_text_npc" : "%1$s bites %2$s with their ratlike incisors",
+            "body_part" : "MOUTH",
+            "chance" : 18,
+            "base_damage" : [
+                { "damage_type" : "cut", "amount" : 3 },
+                { "damage_type" : "bash", "amount" : 3 }
+            ]
+        }
+    },{
+        "type" : "mutation",
+        "id" : "MEMBRANE",
+        "name" : "Nictitating Membrane",
+        "points" : 1,
+        "visibility" : 1,
+        "ugliness" : 2,
+        "description" : "You have a set of clear lenses which lower over your eyes while underwater, allowing you to see as though you were wearing goggles.  Slightly decreases wet penalties.",
+        "prereqs" : ["EYEBULGE"],
+        "category" : ["LIZARD", "FISH"],
+        "wet_protection" : [
+            { "part" : "EYES", "neutral" : 1 }
+        ]
+    },{
+        "type" : "mutation",
+        "id" : "GILLS",
+        "name" : "Gills",
+        "points" : 2,
+        "visibility" : 5,
+        "ugliness" : 3,
+        "description" : "You've grown a set of gills in your neck, allowing you to breathe underwater.  Slightly increases wet benefits.",
+        "category" : ["FISH"],
+        "cancels" : ["GILLS_CEPH"],
+        "wet_protection" : [
+            { "part" : "HEAD", "good" : 1 }
+        ]
+    },{
+        "type" : "mutation",
+        "id" : "GILLS_CEPH",
+        "name" : "Cephalopod Gills",
+        "points" : 2,
+        "visibility" : 4,
+        "ugliness" : 4,
+        "description" : "You've grown a set of gills, running from your neck up behind your ears.  They allow you to breathe underwater and slightly increase wet benefits.",
+        "category" : ["CEPHALOPOD"],
+        "cancels" : ["GILLS"],
+        "wet_protection" : [
+            { "part" : "HEAD", "good" : 1 }
+        ]
+    },{
+        "type" : "mutation",
+        "id" : "M_SKIN",
+        "name" : "Mycus Flesh",
+        "points" : 2,
+        "visibility" : 10,
+        "ugliness" : 8,
+        "description" : "We have begun adapting local physiology to Mycus physical structure, greatly reducing wet effects.",
+        "valid" : false,
+        "purifiable": false,
+        "category" : ["MYCUS"],
+        "prereqs" : ["M_IMMUNE"],
+        "threshreq" : ["THRESH_MYCUS"],
+        "leads_to" : ["M_DEFENDER"],
+        "changes_to" : ["M_SKIN2"],
+        "wet_protection" : [
+            { "part" : "HEAD", "ignored" : 6 },
+            { "part" : "LEG_L", "ignored" : 20 },
+            { "part" : "LEG_R", "ignored" : 20 },
+            { "part" : "FOOT_L", "ignored" : 6 },
+            { "part" : "FOOT_R", "ignored" : 6 },
+            { "part" : "ARM_L", "ignored" : 18 },
+            { "part" : "ARM_R", "ignored" : 18 },
+            { "part" : "HAND_L", "ignored" : 4 },
+            { "part" : "HAND_R", "ignored" : 4 },
+            { "part" : "TORSO", "ignored" : 40 }
+        ],
+        "armor" : [ { "parts" : "ALL", "cut" : 1, "bash" : 2 } ]
+    },{
+        "type" : "mutation",
+        "id" : "M_SKIN2",
+        "name" : "Mycus Fireproofing",
+        "points" : 5,
+        "visibility" : 10,
+        "ugliness" : 8,
+        "description" : "We have spliced the dense, amphibole fibers from Mycus core towers with the resilient, adaptive flesh of local physiology.  This reduces our speed by a moderate amount, but provides powerful armor across our body, nullifies wet effects, and provides complete protection from fire.",
+        "valid" : false,
+        "purifiable": false,
+        "category" : ["MYCUS"],
+        "prereqs" : ["M_SKIN"],
+        "prereqs2" : ["M_DEFENDER"],
+        "threshreq" : ["THRESH_MYCUS"],
+        "changes_to" : ["M_SKIN3"],
+        "wet_protection" : [
+            { "part" : "HEAD", "ignored" : 9 },
+            { "part" : "LEG_L", "ignored" : 30 },
+            { "part" : "LEG_R", "ignored" : 30 },
+            { "part" : "FOOT_L", "ignored" : 9 },
+            { "part" : "FOOT_R", "ignored" : 9 },
+            { "part" : "ARM_L", "ignored" : 24 },
+            { "part" : "ARM_R", "ignored" : 24 },
+            { "part" : "HAND_L", "ignored" : 6 },
+            { "part" : "HAND_R", "ignored" : 6 },
+            { "part" : "TORSO", "ignored" : 60 }
+        ],
+        "armor" : [ { "parts" : "ALL", "cut" : 2, "bash" : 3 } ]
+    },{
+        "type" : "mutation",
+        "id" : "M_SKIN3",
+        "name" : "Mycogenesis",
+        "points" : 7,
+        "visibility" : 10,
+        "ugliness" : 10,
+        "description" : "Local physiology has been fully incorporated with that of Mycus silicate fibers.  In addition to benefits conferred by previous developments, we may join with Mycus fibers beneath us - sleeping on top of fungal areas places us into a dormant state, which spreads spores around us as we sleep and revitalizes our body much more quickly than regular sleep.",
+        "valid" : false,
+        "purifiable": false,
+        "category" : ["MYCUS"],
+        "prereqs" : ["M_SKIN2"],
+        "threshreq" : ["THRESH_MYCUS"],
+        "wet_protection" : [
+            { "part" : "HEAD", "ignored" : 9 },
+            { "part" : "LEG_L", "ignored" : 30 },
+            { "part" : "LEG_R", "ignored" : 30 },
+            { "part" : "FOOT_L", "ignored" : 9 },
+            { "part" : "FOOT_R", "ignored" : 9 },
+            { "part" : "ARM_L", "ignored" : 24 },
+            { "part" : "ARM_R", "ignored" : 24 },
+            { "part" : "HAND_L", "ignored" : 6 },
+            { "part" : "HAND_R", "ignored" : 6 },
+            { "part" : "TORSO", "ignored" : 60 }
+        ],
+        "armor" : [ { "parts" : "ALL", "cut" : 3, "bash" : 5 } ]
+    },{
+        "type" : "mutation",
+        "id" : "SCALES",
+        "name" : "Scales",
+        "points" : 2,
+        "visibility" : 10,
+        "ugliness" : 3,
+        "description" : "A set of flexible green scales has grown to cover your body, acting as natural armor.  Somewhat reduces wet effects.",
+        "types" : ["SKIN"],
+        "category" : ["CHIMERA", "RAPTOR", "LIZARD"],
+        "prereqs" : ["SKIN_ROUGH"],
+        "changes_to" : ["THICK_SCALES", "SLEEK_SCALES"],
+        "wet_protection" : [
+            { "part" : "HEAD", "ignored" : 3 },
+            { "part" : "LEG_L", "ignored" : 10 },
+            { "part" : "LEG_R", "ignored" : 10 },
+            { "part" : "FOOT_L", "ignored" : 3 },
+            { "part" : "FOOT_R", "ignored" : 3 },
+            { "part" : "ARM_L", "ignored" : 9 },
+            { "part" : "ARM_R", "ignored" : 9 },
+            { "part" : "HAND_L", "ignored" : 2 },
+            { "part" : "HAND_R", "ignored" : 2 },
+            { "part" : "TORSO", "ignored" : 20 }
+        ],
+        "armor" : [ { "parts" : "ALL", "cut" : 2 } ]
+    },{
+        "type" : "mutation",
+        "id" : "THICK_SCALES",
+        "name" : "Thick Scales",
+        "points" : 3,
+        "visibility" : 10,
+        "ugliness" : 4,
+        "mixed_effect" : true,
+        "description" : "A set of heavy green scales has grown to cover your body, acting as natural armor.  While difficult to penetrate, it also limits your flexibility, resulting in a -2 penalty to Dexterity.  Greatly reduces wet effects.",
+        "types" : ["SKIN"],
+        "prereqs" : ["SCALES"],
+        "threshreq" : ["THRESH_LIZARD"],
+        "category" : ["LIZARD"],
+        "wet_protection" : [
+            { "part" : "HEAD", "ignored" : 5 },
+            { "part" : "LEG_L", "ignored" : 16 },
+            { "part" : "LEG_R", "ignored" : 16 },
+            { "part" : "FOOT_L", "ignored" : 5 },
+            { "part" : "FOOT_R", "ignored" : 5 },
+            { "part" : "ARM_L", "ignored" : 14 },
+            { "part" : "ARM_R", "ignored" : 14 },
+            { "part" : "HAND_L", "ignored" : 4 },
+            { "part" : "HAND_R", "ignored" : 4 },
+            { "part" : "TORSO", "ignored" : 30 }
+        ],
+        "armor" : [ { "parts" : "ALL", "cut" : 4 } ]
+    },{
+        "type" : "mutation",
+        "id" : "SLEEK_SCALES",
+        "name" : "Sleek Scales",
+        "points" : 4,
+        "visibility" : 10,
+        "ugliness" : 4,
+        "description" : "A set of very flexible and slick scales has grown to cover your body.  These act as weak natural armor, improve your ability to swim, and make you difficult to grab.  Mostly reduces wet effects.",
+        "types" : ["SKIN"],
+        "prereqs" : ["SCALES"],
+        "category" : ["FISH"],
+        "wet_protection" : [
+            { "part" : "HEAD", "good" : 7 },
+            { "part" : "LEG_L", "good" : 21 },
+            { "part" : "LEG_R", "good" : 21 },
+            { "part" : "FOOT_L", "good" : 6 },
+            { "part" : "FOOT_R", "good" : 6 },
+            { "part" : "ARM_L", "good" : 19 },
+            { "part" : "ARM_R", "good" : 19 },
+            { "part" : "HAND_L", "good" : 5 },
+            { "part" : "HAND_R", "good" : 5 },
+            { "part" : "TORSO", "good" : 40 }
+        ],
+        "armor" : [ { "parts" : "ALL", "cut" : 1 } ]
+    },{
+        "type" : "mutation",
+        "id" : "LIGHT_BONES",
+        "name" : "Light Bones",
+        "points" : 2,
+        "description" : "Your bones are very light.  This enables you to move and attack 10% faster, but also reduces your carrying weight by 20% and makes bashing attacks hurt a little more.",
+        "category" : ["MOUSE"],
+        "changes_to" : ["HOLLOW_BONES"]
+    },{
+        "type" : "mutation",
+        "id" : "FEATHERS",
+        "name" : "Feathers",
+        "points" : 2,
+        "visibility" : 10,
+        "ugliness" : 3,
+        "bodytemp_modifiers" : [50, 100],
+        "description" : "Iridescent feathers have grown to cover your entire body, providing a marginal protection against attacks and minor protection from cold.  They also provide a natural waterproofing.",
+        "types" : ["SKIN"],
+        "leads_to" : ["DOWN"],
+        "prereqs" : ["SKIN_ROUGH"],
+        "category" : ["BIRD"],
+        "armor" : [ { "parts" : "ALL", "bash" : 1 } ]
+    },{
+        "type" : "mutation",
+        "id" : "DOWN",
+        "name" : "Down",
+        "points" : 0,
+        "visibility" : 4,
+        "ugliness" : 1,
+        "bodytemp_modifiers" : [300, 800],
+        "bodytemp_sleep" : 250,
+        "description" : "You shan't need to migrate south with your layer of down.  It's even better with no apes around to kill you for it!",
+        "types" : ["SKIN"],
+        "prereqs" : ["FEATHERS"],
+        "threshreq": ["THRESH_BIRD"],
+        "category" : ["BIRD"]
+    },{
+        "type" : "mutation",
+        "id" : "LIGHTFUR",
+        "name" : "Lightly Furred",
+        "points" : 1,
+        "visibility" : 6,
+        "ugliness" : 2,
+        "bodytemp_modifiers" : [250, 500],
+        "bodytemp_sleep" : 100,
+        "description" : "Light fur has grown to cover your entire body, providing slight protection from cold.",
+        "category" : ["CHIMERA", "SPIDER", "MOUSE"],
+        "types" : ["SKIN"],
+        "prereqs" : ["SKIN_ROUGH"],
+        "changes_to" : ["FUR", "FELINE_FUR", "LUPINE_FUR", "URSINE_FUR", "CHITIN_FUR"]
+    },{
+        "type" : "mutation",
+        "id" : "FUR",
+        "name" : "Furry",
+        "points" : 2,
+        "visibility" : 10,
+        "ugliness" : 3,
+        "bodytemp_modifiers" : [750, 1500],
+        "bodytemp_sleep" : 500,
+        "description" : "Thick black fur has grown to cover your entire body, providing a marginal protection against attacks, and considerable protection from cold.",
+        "types" : ["SKIN"],
+        "changes_to" : ["URSINE_FUR"],
+        "prereqs" : ["LIGHTFUR"],
+        "category" : ["BEAST", "CATTLE", "RAT"],
+        "armor" : [ { "parts" : "ALL", "bash" : 1 } ]
+    },{
+        "type" : "mutation",
+        "id" : "URSINE_FUR",
+        "name" : "Shaggy Fur",
+        "points" : 4,
+        "visibility" : 10,
+        "ugliness" : 3,
+        "bodytemp_modifiers" : [750, 1500],
+        "bodytemp_sleep" : 500,
+        "description" : "Your fur has grown out and thickened, providing noticeable protection from attacks as well as considerable insulation.",
+        "types" : ["SKIN"],
+        "prereqs" : ["LIGHTFUR"],
+        "category" : ["URSINE"],
+        "armor" : [ { "parts" : "ALL", "bash" : 1 } ]
+    },{
+        "type" : "mutation",
+        "id" : "LUPINE_FUR",
+        "name" : "Gray Fur",
+        "points" : 2,
+        "visibility" : 10,
+        "ugliness" : 3,
+        "bodytemp_modifiers" : [750, 1500],
+        "bodytemp_sleep" : 500,
+        "description" : "Dense gray fur has grown to cover your entire body, providing a marginal protection against attacks, and considerable protection from cold.",
+        "types" : ["SKIN"],
+        "prereqs" : ["LIGHTFUR"],
+        "category" : ["LUPINE"],
+        "armor" : [ { "parts" : "ALL", "bash" : 1 } ]
+    },{
+        "type" : "mutation",
+        "id" : "FELINE_FUR",
+        "name" : "Sleek Fur",
+        "points" : 2,
+        "visibility" : 10,
+        "ugliness" : 3,
+        "bodytemp_modifiers" : [500, 1000],
+        "bodytemp_sleep" : 300,
+        "description" : "You've grown sleek brown fur, providing some protection from cold.",
+        "types" : ["SKIN"],
+        "prereqs" : ["LIGHTFUR"],
+        "leads_to" : ["LYNX_FUR"],
+        "category" : ["BEAST", "FELINE", "MOUSE"]
+    },{
+        "type" : "mutation",
+        "id" : "LYNX_FUR",
+        "name" : "Lynx Fur",
+        "points" : 1,
+        "visibility" : 8,
+        "ugliness" : 1,
+        "description" : "Your fur has grown out significantly around your cheeks and neck.  It provides minor protection against attacks.",
+        "types" : ["SKIN"],
+        "prereqs" : ["FELINE_FUR"],
+        "category" : ["FELINE"],
+        "armor" : [ { "parts" : [ "HEAD", "MOUTH" ], "bash" : 1 } ]
+    },{
+        "type" : "mutation",
+        "id" : "CHITIN",
+        "name" : "Chitinous Skin",
+        "points" : 2,
+        "visibility" : 3,
+        "ugliness" : 2,
+        "description" : "Your epidermis has turned into a thin, flexible layer of chitin.  It provides minor protection from cutting wounds.  Slightly reduces wet effects.",
+        "types" : ["SKIN"],
+        "prereqs" : ["SKIN_ROUGH"],
+        "changes_to" : ["CHITIN2", "CHITIN_FUR"],
+        "category" : ["SPIDER"],
+        "wet_protection" : [
+            { "part" : "HEAD", "ignored" : 1 },
+            { "part" : "LEG_L", "ignored" : 5 },
+            { "part" : "LEG_R", "ignored" : 5 },
+            { "part" : "FOOT_L", "ignored" : 1 },
+            { "part" : "FOOT_R", "ignored" : 1 },
+            { "part" : "ARM_L", "ignored" : 4 },
+            { "part" : "ARM_R", "ignored" : 4 },
+            { "part" : "HAND_L", "ignored" : 1 },
+            { "part" : "HAND_R", "ignored" : 1 },
+            { "part" : "TORSO", "ignored" : 10 }
+        ],
+        "armor" : [ { "parts" : "ALL", "bash" : 2, "cut" : 2 } ]
+    },{
+        "type" : "mutation",
+        "id" : "CHITIN2",
+        "name" : "Chitinous Armor",
+        "points" : 2,
+        "visibility" : 6,
+        "ugliness" : 3,
+        "mixed_effect" : true,
+        "description" : "You've grown a chitin exoskeleton, much like that of an insect.  It provides considerable physical protection, but reduces your Dexterity by 1.  Somewhat reduces wet effects.",
+        "types" : ["SKIN"],
+        "prereqs" : ["CHITIN"],
+        "changes_to" : ["CHITIN3"],
+        "category" : ["INSECT"],
+        "wet_protection" : [
+            { "part" : "HEAD", "ignored" : 2 },
+            { "part" : "LEG_L", "ignored" : 9 },
+            { "part" : "LEG_R", "ignored" : 9 },
+            { "part" : "FOOT_L", "ignored" : 2 },
+            { "part" : "FOOT_R", "ignored" : 2 },
+            { "part" : "ARM_L", "ignored" : 8 },
+            { "part" : "ARM_R", "ignored" : 8 },
+            { "part" : "HAND_L", "ignored" : 2 },
+            { "part" : "HAND_R", "ignored" : 2 },
+            { "part" : "TORSO", "ignored" : 18 }
+        ],
+        "armor" : [ { "parts" : "ALL", "bash" : 4, "cut" : 4 } ]
+    },{
+        "type" : "mutation",
+        "id" : "CHITIN3",
+        "name" : "Chitinous Plate",
+        "points" : 2,
+        "visibility" : 8,
+        "ugliness" : 5,
+        "description" : "You've grown a chitin exoskeleton made of thick, stiff plates.  It provides excellent physical protection, but reduces your Dexterity by 1 and encumbers all body parts but your eyes and mouth.  Greatly reduces wet effects.",
+        "types" : ["SKIN"],
+        "prereqs" : ["CHITIN2", "CHITIN_FUR2"],
+        "category" : ["SPIDER"],
+        "changes_to" : ["CHITIN_FUR3"],
+        "wet_protection" : [
+            { "part" : "HEAD", "ignored" : 4 },
+            { "part" : "LEG_L", "ignored" : 14 },
+            { "part" : "LEG_R", "ignored" : 14 },
+            { "part" : "FOOT_L", "ignored" : 4 },
+            { "part" : "FOOT_R", "ignored" : 4 },
+            { "part" : "ARM_L", "ignored" : 12 },
+            { "part" : "ARM_R", "ignored" : 12 },
+            { "part" : "HAND_L", "ignored" : 3 },
+            { "part" : "HAND_R", "ignored" : 3 },
+            { "part" : "TORSO", "ignored" : 26 }
+        ],
+        "encumbrance_always" : [
+            [ "TORSO", 10 ],
+            [ "HEAD", 10 ],
+            [ "ARM_L", 10 ],
+            [ "ARM_R", 10 ],
+            [ "HAND_L", 10 ],
+            [ "HAND_R", 10 ],
+            [ "LEG_L", 10 ],
+            [ "LEG_R", 10 ],
+            [ "FOOT_L", 10 ],
+            [ "FOOT_R", 10 ]
+        ],
+        "restricts_gear" : [ "HEAD" ],
+        "armor" : [ { "parts" : "ALL", "bash" : 8, "cut" : 8 } ]
+    },{
+        "type" : "mutation",
+        "id" : "CHITIN_FUR",
+        "name" : "Hairy Chitin",
+        "points" : 3,
+        "visibility" : 10,
+        "ugliness" : 4,
+        "bodytemp_modifiers" : [100, 150],
+        "bodytemp_sleep" : 50,
+        "description" : "You've developed some sort of hair growing out of your chitin.  It's a bit warmer than not having hair.",
+        "types" : ["SKIN"],
+        "prereqs" : ["CHITIN", "LIGHTFUR"],
+        "category" : ["SPIDER"],
+        "changes_to" : ["CHITIN_FUR2"],
+        "armor" : [ { "parts" : "ALL", "bash" : 2, "cut" : 2 } ]
+    },{
+        "type" : "mutation",
+        "id" : "CHITIN_FUR2",
+        "name" : "Furred Chitin",
+        "points" : 4,
+        "visibility" : 10,
+        "ugliness" : 4,
+        "bodytemp_modifiers" : [150, 250],
+        "bodytemp_sleep" : 75,
+        "description" : "Your chitin hair has thickened and spread across your body.  It provides minor warmth and helps you sense nearby vibrations.",
+        "types" : ["SKIN"],
+        "prereqs" : ["CHITIN_FUR"],
+        "category" : ["SPIDER"],
+        "changes_to" : ["CHITIN_FUR3", "CHITIN3"],
+        "armor" : [ { "parts" : "ALL", "bash" : 4, "cut" : 4 } ]
+    },{
+        "type" : "mutation",
+        "id" : "CHITIN_FUR3",
+        "name" : "Furred Plate",
+        "points" : 5,
+        "visibility" : 10,
+        "ugliness" : 4,
+        "bodytemp_modifiers" : [150, 250],
+        "bodytemp_sleep" : 75,
+        "description" : "Your exoskeleton has hardened considerably--restricting movement, granted--and boasts a fine coat of hairs that put feline whiskers to shame.",
+        "encumbrance_always" : [
+            [ "TORSO", 10 ],
+            [ "HEAD", 10 ],
+            [ "ARM_L", 10 ],
+            [ "ARM_R", 10 ],
+            [ "HAND_L", 10 ],
+            [ "HAND_R", 10 ],
+            [ "LEG_L", 10 ],
+            [ "LEG_R", 10 ],
+            [ "FOOT_L", 10 ],
+            [ "FOOT_R", 10 ]
+        ],
+        "types" : ["SKIN"],
+        "prereqs" : ["CHITIN_FUR2", "CHITIN3"],
+        "threshreq" : ["THRESH_SPIDER"],
+        "category" : ["SPIDER"],
+        "restricts_gear" : [ "HEAD" ],
+        "armor" : [ { "parts" : "ALL", "bash" : 8, "cut" : 8 } ]
+    },{
+        "type" : "mutation",
+        "id" : "CF_HAIR",
+        "name" : "Urticating Hairs",
+        "points" : 3,
+        "visibility" : 1,
+        "ugliness" : 1,
+        "description" : "Significant amounts of your hairs have loosened.  If some creature tries to attack you, your assailant is quite likely to get fine, bristly chitin in an irritating spot; it doesn't carry your venom but it will be distracting.",
+        "prereqs" : ["CHITIN_FUR2", "CHITIN_FUR3"],
+        "threshreq" : ["THRESH_SPIDER"],
+        "category" : ["SPIDER"]
+    },{
+        "type" : "mutation",
+        "id" : "SPINES",
+        "name" : "Spines",
+        "points" : 1,
+        "visibility" : 1,
+        "ugliness" : 2,
+        "description" : "Your skin is covered with fine spines.  Whenever an unarmed opponent strikes a part of your body that is not covered by clothing, they will receive moderate damage.",
+        "changes_to" : ["QUILLS"]
+    },{
+        "type" : "mutation",
+        "id" : "QUILLS",
+        "name" : "Quills",
+        "points" : 2,
+        "visibility" : 3,
+        "ugliness" : 3,
+        "description" : "Your body is covered with large quills.  Whenever an unarmed opponent strikes a part of your body that is not covered by clothing, they will receive significant damage.",
+        "prereqs" : ["SPINES"]
+    },{
+        "type" : "mutation",
+        "id" : "PLANTSKIN",
+        "name" : "Phelloderm",
+        "points" : 3,
+        "visibility" : 3,
+        "ugliness" : 2,
+        "description" : "Your skin is light green and has a slightly woody quality to it.  This provides a weak armor, and helps you retain moisture, resulting in less thirst.  Greatly decreases wet penalties.",
+        "types" : ["SKIN"],
+        "changes_to" : ["BARK"],
+        "leads_to" : ["THORNS", "LEAVES"],
+        "category": ["PLANT", "ELFA"],
+        "wet_protection" : [
+            { "part" : "HEAD", "neutral" : 4 },
+            { "part" : "LEG_L", "neutral" : 5 },
+            { "part" : "LEG_R", "neutral" : 5 },
+            { "part" : "FOOT_L", "neutral" : 1 },
+            { "part" : "FOOT_R", "neutral" : 1 },
+            { "part" : "ARM_L", "neutral" : 4 },
+            { "part" : "ARM_R", "neutral" : 4 },
+            { "part" : "HAND_L", "neutral" : 1 },
+            { "part" : "HAND_R", "neutral" : 1 },
+            { "part" : "TORSO", "neutral" : 10 }
+        ],
+        "armor" : [ { "parts" : "ALL", "cut" : 1 } ],
+        "thirst_modifier": -0.2
+    },{
+        "type" : "mutation",
+        "id" : "BARK",
+        "name" : "Bark",
+        "points" : 5,
+        "visibility" : 10,
+        "ugliness" : 3,
+        "description" : "Your skin is coated in a light bark, like that of a tree.  This provides resistance to cutting damage and minor protection from fire.  Greatly reduces wet effects.",
+        "types" : ["SKIN"],
+        "prereqs" : ["PLANTSKIN"],
+        "category" : ["PLANT"],
+        "wet_protection" : [
+            { "part" : "HEAD", "ignored" : 5 },
+            { "part" : "LEG_L", "ignored" : 16 },
+            { "part" : "LEG_R", "ignored" : 16 },
+            { "part" : "FOOT_L", "ignored" : 5 },
+            { "part" : "FOOT_R", "ignored" : 5 },
+            { "part" : "ARM_L", "ignored" : 14 },
+            { "part" : "ARM_R", "ignored" : 14 },
+            { "part" : "HAND_L", "ignored" : 4 },
+            { "part" : "HAND_R", "ignored" : 4 },
+            { "part" : "TORSO", "ignored" : 30 }
+        ],
+        "armor" : [ { "parts" : "ALL", "cut" : 2 } ]
+    },{
+        "type" : "mutation",
+        "id" : "THORNS",
+        "name" : "Thorns",
+        "points" : 2,
+        "visibility" : 8,
+        "ugliness" : 4,
+        "description" : "Your skin is covered in small, woody thorns.  Whenever an unarmed opponent strikes a part of your body that is not covered by clothing, they will receive minor damage.  Your punches may also deal extra damage.",
+        "prereqs" : ["BARK"],
+        "category" : ["PLANT"]
+    },{
+        "type" : "mutation",
+        "id" : "LEAVES",
+        "name" : "Leaves",
+        "points" : 6,
+        "visibility" : 8,
+        "ugliness" : 3,
+        "description" : "All the hair on your body has turned to long, grass-like leaves.  Apart from being physically striking, these provide you with a minor amount of nutrition while in sunlight.  Slightly reduces wet effects.",
+        "prereqs" : ["PLANTSKIN", "BARK"],
+        "category" : ["PLANT", "ELFA"],
+        "wet_protection" : [
+            { "part" : "HEAD", "ignored" : 1 }
+        ]
+    },{
+        "type" : "mutation",
+        "id" : "FLOWERS",
+        "name" : "Flowering",
+        "points" : 2,
+        "visibility" : 10,
+        "ugliness" : -4,
+        "description" : "You've started blooming where your scalp used to be.  Your blossoms have a pleasant aroma, are visually striking, and are quite sensitive.",
+        "prereqs" : ["PLANTSKIN","BARK"],
+        "prereqs2" : ["LEAVES"],
+        "cancels" : ["SMELLY", "SMELLY2"],
+        "threshreq" : ["THRESH_PLANT"],
+        "category" : ["PLANT"],
+        "social_modifiers" : {
+            "lie" : 10
+        }
+    },{
+        "type" : "mutation",
+        "id" : "M_SPORES",
+        "name" : "Mycus Spores",
+        "points" : 4,
+        "visibility" : 10,
+        "ugliness" : 4,
+        "description" : "We have developed local spore sacs.  The Mycus must grow.",
+        "valid" : false,
+        "prereqs" : ["M_DEPENDENT"],
+        "changes_to" : ["M_FERTILE"],
+        "cancels" : ["M_BLOSSOMS", "M_BLOOM"],
+        "threshreq" : ["THRESH_MYCUS"],
+        "category" : ["MYCUS"]
+    },{
+        "type" : "mutation",
+        "id" : "M_FERTILE",
+        "name" : "Mycus Sporogenesis",
+        "points" : 6,
+        "visibility" : 5,
+        "ugliness" : 3,
+        "description" : "Local organisms seem to regard open spore-dispersal as a danger, and attack the Mycus.  Accordingly our local spore sacs remain quiescent, until local guidance determines that it is safe to germinate.  Rapid development taxes local nutrient reserves but ensures swift and effective growth.",
+        "valid" : false,
+        "changes_to" : ["M_PROVENANCE"],
+        "prereqs" : ["M_SPORES"],
+        "cancels" : ["M_BLOSSOMS", "M_BLOOM"],
+        "threshreq" : ["THRESH_MYCUS"],
+        "category" : ["MYCUS"],
+        "active"     :    true,
+        "cost"       :    8,
+        "hunger"     :    true,
+        "thirst"     :    true
+    },{
+        "type" : "mutation",
+        "id" : "M_BLOSSOMS",
+        "name" : "Mycus Blossoms",
+        "points" : 4,
+        "visibility" : 10,
+        "ugliness" : 3,
+        "description" : "We have developed local blossoms.  The Mycus must grow.",
+        "valid" : false,
+        "prereqs" : ["M_DEPENDENT"],
+        "prereqs2" : ["M_IMMUNE"],
+        "changes_to" : ["M_BLOOM"],
+        "cancels" : ["M_SPORES", "M_FERTILE"],
+        "threshreq" : ["THRESH_MYCUS"],
+        "category" : ["MYCUS"]
+    },{
+        "type" : "mutation",
+        "id" : "M_BLOOM",
+        "name" : "Mycus Bloom",
+        "points" : 6,
+        "visibility" : 10,
+        "ugliness" : 1,
+        "description" : "Local organisms seem to regard open spore-dispersal as a danger, and attack the Mycus.  Accordingly our local blossoms remain quiescent, until local guidance determines that it is safe to germinate.  Rapid development taxes local nutrient reserves but ensures swift and effective growth.",
+        "valid" : false,
+        "changes_to" : ["M_PROVENANCE"],
+        "cancels" : ["M_SPORES", "M_FERTILE"],
+        "prereqs" : ["M_BLOSSOMS"],
+        "threshreq" : ["THRESH_MYCUS"],
+        "category" : ["MYCUS"],
+        "active"     :    true,
+        "cost"       :    10,
+        "hunger"     :    true,
+        "thirst"     :    true,
+        "fatigue"    :    true
+    },{
+        "type" : "mutation",
+        "id" : "M_PROVENANCE",
+        "name" : "Mycus Provenance",
+        "points" : 8,
+        "visibility" : 10,
+        "ugliness" : -3,
+        "description" : "Local spore sacs and blossoms have merged into a single, symbiotic form.  Acting as one, they germinate together to cement rapid growth across a large area according to local guidance.  The Mycus must grow.",
+        "valid" : false,
+        "purifiable" : false,
+        "cancels" : ["M_FERTILE", "M_BLOOM", "M_SPORES", "M_BLOSSOMS"],
+        "threshreq" : ["THRESH_MYCUS"],
+        "category" : ["MYCUS"],
+        "active" : true,
+        "cost" : 10,
+        "hunger" : true,
+        "thirst" : true,
+        "fatigue" : true
+    },{
+        "type" : "mutation",
+        "id" : "NAILS",
+        "name" : "Long Fingernails",
+        "points" : 1,
+        "visibility" : 1,
+        "description" : "Your fingernails are long and sharp.  If you aren't wearing gloves, your unarmed attacks deal a minor amount of cutting damage.",
+        "types" : ["CLAWS"],
+        "changes_to" : ["CLAWS", "TALONS"],
+        "cancels" : ["ARM_TENTACLES", "ARM_TENTACLES_4", "ARM_TENTACLES_8"],
+        "category" : ["RAPTOR"]
+    },{
+        "type" : "mutation",
+        "id" : "CLAWS",
+        "name" : "Claws",
+        "points" : 2,
+        "visibility" : 3,
+        "ugliness" : 2,
+        "description" : "You have claws on the ends of your fingers.  If you aren't wearing gloves, your unarmed attacks deal a minor amount of cutting damage.",
+        "types" : ["CLAWS"],
+        "prereqs" : ["NAILS"],
+        "changes_to" : ["CLAWS_RETRACT", "CLAWS_RAT"],
+        "cancels" : ["ARM_TENTACLES", "ARM_TENTACLES_4", "ARM_TENTACLES_8"],
+        "category" : ["BEAST", "RAT", "URSINE"]
+    },{
+        "type" : "mutation",
+        "id" : "CLAWS_RAT",
+        "name" : "Rat Claws",
+        "points" : 3,
+        "visibility" : 3,
+        "ugliness" : 4,
+        "description" : "Your claws have grown tougher and slightly gnarled.",
+        "types" : ["CLAWS"],
+        "prereqs" : ["CLAWS"],
+        "changes_to" : ["CLAWS_ST"],
+        "cancels" : ["ARM_TENTACLES", "ARM_TENTACLES_4", "ARM_TENTACLES_8"],
+        "category" : ["RAT"]
+    },{
+        "type" : "mutation",
+        "id" : "CLAWS_ST",
+        "name" : "Stainless Claws",
+        "points" : 6,
+        "visibility" : 3,
+        "ugliness" : 5,
+        "valid" : false,
+        "purifiable" : false,
+        "description" : "Your paws are bone, muscle, and claw with a thin layer of skin and fur.  They might as well be made of stainless steel.",
+        "types" : ["CLAWS"],
+        "prereqs" : ["CLAWS_RAT"],
+        "prereqs2" : ["PAWS"],
+        "threshreq" : ["THRESH_RAT"],
+        "cancels" : ["ARM_TENTACLES", "ARM_TENTACLES_4", "ARM_TENTACLES_8"],
+        "category" : ["RAT"]
+    },{
+        "type" : "mutation",
+        "id" : "CLAWS_RETRACT",
+        "name" : "Retractable Claws",
+        "points" : 2,
+        "ugliness" : 1,
+        "description" : "You have claws on the ends of your fingers, and can extend or retract them as desired.  Gloves will still get in the way, though.",
+        "types" : ["CLAWS"],
+        "prereqs" : ["CLAWS"],
+        "cancels" : ["ARM_TENTACLES", "ARM_TENTACLES_4", "ARM_TENTACLES_8"],
+        "category" : ["FELINE"],
+        "active"     :    true,
+        "cost"       :    0
+    },{
+        "type" : "mutation",
+        "id" : "CLAWS_TENTACLE",
+        "name" : "Tentacle Rakes",
+        "points" : 0,
+        "visibility" : 4,
+        "ugliness" : 4,
+        "mixed_effect" : true,
+        "description" : "Your upper tentacles have grown large, hook-barbed rakes on the ends.  They're quite vicious, but really aren't suited for fine manipulation.",
+        "encumbrance_always" : [
+            [ "HAND_L", 20 ],
+            [ "HAND_R", 20 ]
+        ],
+        "prereqs" : ["ARM_TENTACLES", "ARM_TENTACLES_4", "ARM_TENTACLES_8"],
+        "threshreq" : ["THRESH_CEPHALOPOD"],
+        "category" : ["CEPHALOPOD"]
+    },{
+        "type" : "mutation",
+        "id" : "TALONS",
+        "name" : "Large Talons",
+        "points" : 2,
+        "visibility" : 4,
+        "ugliness" : 3,
+        "mixed_effect" : true,
+        "restricts_gear" : [ "HAND_L", "HAND_R" ],
+        "destroys_gear" : true,
+        "description" : "Your index fingers have grown into huge talons.  After a bit of practice, you find that this does not affect your dexterity, but allows for a deadly unarmed attack.  They also prevent wearing gloves.",
+        "types" : ["CLAWS"],
+        "prereqs" : ["NAILS"],
+        "cancels" : ["ARM_TENTACLES", "ARM_TENTACLES_4", "ARM_TENTACLES_8"],
+        "category" : ["LIZARD", "BIRD", "CHIMERA"]
+    },{
+        "type" : "mutation",
+        "id" : "RADIOGENIC",
+        "name" : "Radiogenic",
+        "points" : 3,
+        "description" : "Your system has adapted to radiation.  While irradiated, you will actually heal slowly, converting the radiation into hit points.",
+        "category" : ["SLIME", "MEDICAL"]
+    },{
+        "type" : "mutation",
+        "id" : "MARLOSS",
+        "name" : "Marloss Carrier",
+        "points" : 4,
+        "description" : "Ever since you ate that Marloss berry, you can't get its scent out of your nose, and you have a strong desire to try some seeds and...sap?",
+        "purifiable": false,
+        "valid" : false,
+        "category" : ["MARLOSS"]
+    },{
+        "type" : "mutation",
+        "id" : "MARLOSS_BLUE",
+        "name" : "Marloss Vessel",
+        "points" : 4,
+        "description" : "Ever since you ate that Marloss seed, you can't get its taste off of your tongue, and you have a strong desire to try some berries and...sap?",
+        "purifiable": false,
+        "valid" : false,
+        "category" : ["MARLOSS"]
+    },{
+        "type" : "mutation",
+        "id" : "MARLOSS_YELLOW",
+        "name" : "Marloss Vector",
+        "points" : 4,
+        "description" : "Ever since you ate that Marloss jelly, you can't stop thinking of it, and you have a strong desire to eat some seeds and berries.",
+        "purifiable": false,
+        "valid" : false,
+        "category" : ["MARLOSS"]
+    },{
+        "type" : "mutation",
+        "id" : "MARLOSS_AVOID",
+        "name" : "Marloss Rejection",
+        "points" : 0,
+        "description" : "Ever since you had that life-threatening reaction to that Marloss junk, you can't bear the thought of ever eating it again!",
+        "purifiable": false,
+        "valid" : false
+    },{
+        "type" : "mutation",
+        "id" : "MUTAGEN_AVOID",
+        "name" : "Mutagenic Aversion",
+        "points" : 0,
+        "description" : "Ever since you had that life-threatening reaction to those mutagen and purifier things, you can't bear the thought of ever using them again!",
+        "purifiable": false,
+        "valid" : false
+    },{
+        "type" : "mutation",
+        "id" : "PHEROMONE_INSECT",
+        "name" : "Insect Pheromones",
+        "points" : 2,
+        "description" : "Your body produces low-level pheromones, identifying you as a friend to many species of insects.  Insects will attack you much less.",
+        "prereqs" : ["SMELLY2"],
+        "types" : ["SCENT"],
+        "category" : ["INSECT"]
+    },{
+        "type" : "mutation",
+        "id" : "PHEROMONE_MAMMAL",
+        "name" : "Mammal Pheromones",
+        "points" : 2,
+        "description" : "Your body produces low-level pheromones which put mammals at ease.  They will be less likely to attack or flee from you.",
+        "prereqs" : ["SMELLY2"],
+        "types" : ["SCENT"],
+        "category" : ["BEAST", "CATTLE"]
+    },{
+        "type" : "mutation",
+        "id" : "DISIMMUNE",
+        "name" : "Disease Immune",
+        "points" : 2,
+        "description" : "Your body is simply immune to diseases.  You will never catch an ambient disease.",
+        "prereqs" : ["DISRESISTANT"],
+        "category" : ["PLANT", "SLIME", "TROGLOBITE"]
+    },{
+        "type" : "mutation",
+        "id" : "INFRESIST",
+        "name" : "Infection Resistant",
+        "points" : 2,
+        "description" : "Your immune system is particularly good at resisting infections.  You have an increased chance for bad wounds and infections to heal on their own, and only suffer reduced penalties from them.",
+        "starting_trait" : true,
+        "changes_to" : ["INFIMMUNE"],
+        "category" : ["TROGLOBITE", "RAT", "MEDICAL"]
+    },{
+        "type" : "mutation",
+        "id" : "INFIMMUNE",
+        "name" : "Infection Immune",
+        "points" : 3,
+        "description" : "Your bloodstream has developed antibiotic properties.  Your wounds will never become infected.",
+        "prereqs" : ["DISRESISTANT"],
+        "prereqs2" : ["INFRESIST"],
+        "category" : ["MEDICAL"]
+    },{
+        "type" : "mutation",
+        "id" : "M_IMMUNE",
+        "name" : "Mycus Identity",
+        "points" : 5,
+        "description" : "We have synchronized our local physiology with that of the Mycus.  Any spores we may encounter will not attempt to germinate inside the local system, and we may traverse Mycus biospheres easily, as native bioforms shift shape to accommodate us.",
+        "valid" : false,
+        "purifiable": false,
+        "threshreq" : ["THRESH_MYCUS"],
+        "category" : ["MYCUS"]
+    },{
+        "type" : "mutation",
+        "id" : "PARAIMMUNE",
+        "name" : "Parasite Immune",
+        "points" : 1,
+        "description" : "Your body is unusually inhospitable to parasitic lifeforms.  You will never become infested with internal parasites.",
+        "prereqs" : ["DISRESISTANT"],
+        "prereqs2" : ["INFRESIST"],
+        "category" : ["ELFA", "CHIMERA", "MEDICAL", "SLIME"]
+    },{
+        "type" : "mutation",
+        "id" : "POISONOUS",
+        "name" : "Venomous",
+        "points" : 1,
+        "description" : "Your body produces a potent venom.  Cutting or stabbing attacks from mutations have a chance to poison your target.",
+        "prereqs" : ["POISRESIST"],
+        "leads_to" : ["EATPOISON"],
+        "changes_to" : ["POISONOUS2"],
+        "category" : ["SLIME", "TROGLOBITE", "SPIDER"]
+    },{
+        "type" : "mutation",
+        "id" : "POISONOUS2",
+        "name" : "Strongly Venomous",
+        "points" : 2,
+        "description" : "Your venom has become particularly strong.  You're confident that your bites or other cutting/stabbing natural attacks will take your target down quickly.",
+        "prereqs" : ["POISONOUS"],
+        "threshreq" : ["THRESH_SPIDER"],
+        "category" : ["SPIDER"]
+    },{
+        "type" : "mutation",
+        "id" : "SLIME_HANDS",
+        "name" : "Slime Hands",
+        "points" : 1,
+        "visibility" : 5,
+        "ugliness" : 4,
+        "description" : "The skin on your hands is a mucous membrane and produces a thick, acrid slime.  Attacks using your hand will cause minor acid damage.  Slightly increases wet benefits.",
+        "prereqs" : ["SLIMY"],
+        "category" : ["SLIME"],
+        "wet_protection" : [
+            { "part" : "HAND_L", "good" : 5 },
+            { "part" : "HAND_R", "good" : 5 }
+        ]
+    },{
+        "type" : "mutation",
+        "id" : "BENDY1",
+        "name" : "Stretchy Limbs",
+        "points" : 1,
+        "visibility" : 1,
+        "description" : "Your limbs seem to have a little more 'give' to them.  +1 Dexterity.",
+        "changes_to" : ["BENDY2"],
+        "threshreq" : ["THRESH_SLIME", "THRESH_ELFA"],
+        "category" : ["SLIME", "ELFA"],
+        "passive_mods" : {
+            "dex_mod" : 1
+        }
+    },{
+        "type" : "mutation",
+        "id" : "BENDY2",
+        "name" : "Rubbery Limbs",
+        "points" : 1,
+        "visibility" : 1,
+        "mixed_effect" : true,
+        "description" : "Your limbs are significantly more flexible than any pathetic human arm or leg.  +3 Dexterity, -2 Strength.",
+        "purifiable" : false,
+        "prereqs" : ["BENDY1"],
+        "changes_to" : ["BENDY3"],
+        "threshreq" : ["THRESH_SLIME"],
+        "leads_to" : ["AMORPHOUS"],
+        "category" : ["SLIME"],
+        "passive_mods" : {
+            "dex_mod" : 3,
+            "str_mod" : -2
+        },
+        "hp_adjustment": 3
+    },{
+        "type" : "mutation",
+        "id" : "BENDY3",
+        "name" : "Pseudolimbs",
+        "points" : 0,
+        "visibility" : 2,
+        "ugliness" : 2,
+        "mixed_effect" : true,
+        "description" : "Your pseudopod-like limbs can fit into anything!  +4 Dexterity, -4 Strength.",
+        "valid" : false,
+        "purifiable" : false,
+        "prereqs" : ["BENDY2"],
+        "prereqs2" : ["AMORPHOUS"],
+        "threshreq" : ["THRESH_SLIME"],
+        "category" : ["SLIME"],
+        "passive_mods" : {
+            "dex_mod" : 4,
+            "str_mod" : -4
+        },
+        "hp_adjustment": 6
+    },{
+        "type" : "mutation",
+        "id" : "COMPOUND_EYES",
+        "name" : "Compound Eyes",
+        "points" : 2,
+        "visibility" : 9,
+        "ugliness" : 5,
+        "description" : "Your eyes are compound, like those of an insect.  This increases your Perception by 2 so long as you aren't wearing eyewear.",
+        "cancels" : ["ELFAEYES", "FEL_EYE", "URSINE_EYE", "BIRD_EYE", "LIZ_EYE"],
+        "prereqs" : ["EYEBULGE"],
+        "category" : ["INSECT"]
+    },{
+        "type" : "mutation",
+        "id" : "PADDED_FEET",
+        "name" : "Padded Feet",
+        "points" : 1,
+        "visibility" : 1,
+        "description" : "The bottoms of your feet are strongly padded.  You receive no movement penalty for not wearing shoes, and even receive a 10% bonus when moving barefoot.",
+        "types" : ["LEGS"],
+        "category" : ["BEAST", "URSINE", "FELINE", "LUPINE"]
+    },{
+        "type" : "mutation",
+        "id" : "RAP_TALONS",
+        "name" : "Toe Talons",
+        "points" : -1,
+        "visibility" : 4,
+        "ugliness" : 2,
+        "mixed_effect" : true,
+        "description" : "You have grown large, curved, and wickedly sharp talons in place of your big toes.  Fortunately, they don't get in the way of your movement.  Unfortunately, they do prevent wearing footgear.",
+        "valid" : false,
+        "types" : ["LEGS"],
+        "category" : ["RAPTOR"],
+        "restricts_gear" : [ "FOOT_L", "FOOT_R" ],
+        "destroys_gear" : true,
+        "attacks" : {
+            "attack_text_u" : "You slash %s with a talon",
+            "attack_text_npc" : "%1$s slashes %2$s with a talon",
+            "chance" : 20,
+            "strength_damage" : { "damage_type" : "cut", "amount" : 4 }
+        }
+    },{
+        "type" : "mutation",
+        "id" : "HOOVES",
+        "name" : "Hooves",
+        "points" : -4,
+        "visibility" : 2,
+        "ugliness" : 2,
+        "mixed_effect" : true,
+        "description" : "Your feet have fused into hooves.  This allows kicking attacks to do much more damage, provides natural armor, and removes the need to wear shoes; however, you cannot wear shoes of any kind.  Reduces wet effects.",
+        "types" : ["LEGS"],
+        "category" : ["CATTLE", "CHIMERA"],
+        "wet_protection":[
+            { "part" : "FOOT_L", "neutral" : 10 },
+            { "part" : "FOOT_R", "neutral" : 10 }
+        ],
+        "restricts_gear" : [ "FOOT_L", "FOOT_R" ],
+        "destroys_gear" : true,
+        "armor" : [ { "parts" : [ "FOOT_L", "FOOT_R" ], "bash" : 1 } ],
+        "attacks" : {
+            "attack_text_u" : "You kick %s with your hooves",
+            "attack_text_npc" : "%1$s kicks %2$s with their hooves",
+            "chance" : 15,
+            "strength_damage" : { "damage_type" : "bash", "amount" : 3 }
+        }
+    },{
+        "type" : "mutation",
+        "id" : "ALCMET",
+        "name" : "Alcohol Metabolism",
+        "points" : 2,
+        "description" : "So it's fermented?  Whatever, it's still good drinking.  You've developed the ability to metabolize alcohol as a food source.",
+        "prereqs" : ["TOLERANCE"],
+        "prereqs2" : ["SAPROVORE"],
+        "category" : ["TROGLOBITE"],
+        "valid" : false
+    },{
+        "type" : "mutation",
+        "id" : "PAINRESIST_TROGLO",
+        "name" : "Subterranean Fortitude",
+        "points" : 2,
+        "description" : "The aches and pains of living underground don't bother you as much.",
+        "prereqs" : ["PAINRESIST"],
+        "prereqs2" : ["STOCKY_TROGLO"],
+        "threshreq" : ["THRESH_TROGLOBITE"],
+        "category" : ["TROGLOBITE"]
+    },{
+        "type" : "mutation",
+        "id" : "STOCKY_TROGLO",
+        "name" : "Subterranean Build",
+        "points" : 0,
+        "visibility" : 3,
+        "ugliness" : 2,
+        "description" : "Your frame has adapted for life in confined spaces.  You seem a little shorter and bulkier, trading muscle mass for mobility.  (+2 Strength, -2 Dexterity)",
+        "threshreq" : ["THRESH_TROGLOBITE"],
+        "category" : ["TROGLOBITE"],
+        "passive_mods" : {
+            "str_mod" : 2,
+            "dex_mod" : -2
+        }
+    },{
+        "type" : "mutation",
+        "id" : "SAPROVORE",
+        "name" : "Saprovore",
+        "points" : 2,
+        "description" : "Your digestive system is specialized to allow you to consume decaying material.  You can eat rotten food, albeit for less nutrition than usual.",
+        "prereqs" : ["CARNIVORE"],
+        "cancels" : ["HERBIVORE", "RUMINANT"],
+        "category" : ["TROGLOBITE", "CHIMERA"]
+    },{
+        "type" : "mutation",
+        "id" : "SAPROPHAGE",
+        "name" : "Saprophage",
+        "points" : -3,
+        "visibility" : 5,
+        "ugliness" : 9,
+        "description" : "You prefer to sustain yourself using your roots and direct nutrient extraction/synthesis.  You can still consume 'food', though, if you have to: you merely prefer it aged a little.",
+        "prereqs" : ["ROOTS2"],
+        "prereqs2" : ["LEAVES"],
+        "threshreq" : ["THRESH_PLANT"],
+        "cancels" : ["HERBIVORE", "CARNIVORE", "GRAZER"],
+        "leads_to" : ["CHLOROMORPH"],
+        "category" : ["PLANT"]
+    },{
+        "type" : "mutation",
+        "id" : "GIZZARD",
+        "name" : "Gizzard",
+        "points" : -5,
+        "description" : "You seem to get full faster now, and food goes through you more rapidly as well.",
+        "valid" : false,
+        "purifiable" : false,
+        "prereqs" : ["BEAK", "BEAK_PECK", "BEAK_HUM"],
+        "prereqs2" : ["LIGHTEATER"],
+        "threshreq" : ["THRESH_BIRD"],
+        "cancels" : ["GOURMAND"],
+        "category" : ["BIRD"]
+    },{
+        "type" : "mutation",
+        "id" : "M_DEPENDENT",
+        "name" : "Mycus Feeder",
+        "points" : -5,
+        "description" : "We have streamlined our nutritional requirements.  We rely on the Mycus for sustenance, as it relies on us.  We may locate sources of sustenance within the close proximity of Mycus core towers, and in forested areas that the Mycus has grown into.",
+        "valid" : false,
+        "purifiable" : false,
+        "threshreq" : ["THRESH_MYCUS"],
+        "cancels" : ["GOURMAND", "BEAK", "BEAK_PECK", "BEAK_HUM"],
+        "category" : ["MYCUS"]
+    },{
+        "type" : "mutation",
+        "id" : "RUMINANT",
+        "name" : "Ruminant",
+        "points" : 2,
+        "description" : "Your digestive system is capable of digesting cellulose and other rough plant material.  You can eat underbrush and shrubs by activating this, standing over your target, and pressing E.",
+        "prereqs" : ["HERBIVORE"],
+        "changes_to" : ["GRAZER"],
+        "cancels" : ["CARNIVORE", "SAPROVORE"],
+        "category" : ["CATTLE"],
+        "active"     :   true,
+        "cost"       :    0
+    },{
+        "type" : "mutation",
+        "id" : "GRAZER",
+        "name" : "Grazer",
+        "points" : 3,
+        "description" : "You're accustomed to eating plants directly, and can get nutrition from grass as well as underbrush and shrubs.  Eat either one by activating this, standing over your target, and pressing E.",
+        "prereqs" : ["RUMINANT"],
+        "threshreq" : ["THRESH_CATTLE"],
+        "cancels" : ["CARNIVORE", "SAPROVORE"],
+        "category" : ["CATTLE"],
+        "active"     :   true,
+        "cost"       :    0
+    },{
+        "type" : "mutation",
+        "id" : "EATPOISON",
+        "name" : "Intestinal Fortitude",
+        "points" : 3,
+        "description" : "Your guts have developed the ability to handle poisonous food.  Mostly.",
+        "changes_to" : ["EATDEAD"],
+        "prereqs" : ["NAUSEA", "VOMITOUS", "POISRESIST", "POISONOUS"],
+        "//" : "Yes, you eventually got over the massive digestive upset.  Mutations aren't easy on a system!",
+        "prereqs2" : ["SAPROVORE", "TOLERANCE"],
+        "threshreq" : ["THRESH_TROGLOBITE", "THRESH_CHIMERA", "THRESH_RAPTOR", "THRESH_RAT", "THRESH_MOUSE"],
+        "category" : ["TROGLOBITE", "RAPTOR", "RAT", "CHIMERA"],
+        "valid" : false
+    },{
+        "type" : "mutation",
+        "id" : "EATDEAD",
+        "name" : "Eater Of The Dead",
+        "points" : 4,
+        "description" : "Eating rotting, long-dead flesh is good for the struggle, and safe--if still completely unappealing--for you.",
+        "prereqs" : ["EATPOISON"],
+        "threshreq" : ["THRESH_CHIMERA", "THRESH_RAT", "THRESH_MOUSE"],
+        "category" : ["RAT", "CHIMERA", "MOUSE"],
+        "valid" : false
+    },{
+        "type" : "mutation",
+        "id" : "BURROW",
+        "name" : "Burrowing",
+        "points" : 10,
+        "valid" : false,
+        "purifiable" : false,
+        "description" : "Between your claws and teeth, you can tunnel through just about anything.",
+        "prereqs" : ["CLAWS_ST"],
+        "prereqs2" : ["INCISORS"],
+        "threshreq" : ["THRESH_RAT"],
+        "category" : ["RAT"],
+        "active" : true
+    },{
+        "type" : "mutation",
+        "id" : "SABER_TEETH",
+        "name" : "Saber Teeth",
+        "points" : -2,
+        "visibility" : 10,
+        "ugliness" : 8,
+        "mixed_effect" : true,
+        "description" : "Your fangs have grown extremely large and incredibly sharp.  They make it impossible to wear mouthgear and difficult to eat...  but leave nasty wounds when you bite.",
+        "types" : ["TEETH"],
+        "prereqs" : ["FANGS"],
+        "threshreq" : ["THRESH_FELINE", "THRESH_CHIMERA"],
+        "category" : ["FELINE", "CHIMERA"],
+        "restricts_gear" : [ "MOUTH" ],
+        "destroys_gear" : true,
+        "social_modifiers" : {
+            "intimidate" : 15
+        },
+        "attacks" : {
+            "attack_text_u" : "You tear into %s with your saber teeth",
+            "attack_text_npc" : "%1$s tears into %2$s with their saber teeth",
+            "body_part" : "MOUTH",
+            "chance" : 20,
+            "base_damage" : { "damage_type" : "stab", "amount" : 25 },
+            "strength_damage" : { "damage_type" : "stab", "amount" : 1 }
+        }
+    },{
+        "type" : "mutation",
+        "id" : "EATHEALTH",
+        "name" : "Hyper-Metabolism",
+        "points" : 15,
+        "description" : "You metabolize nutrients so rapidly that you can convert food directly into useful tissue.  Excess nutrition will convert to HP, rather than being wasted.  Activate to skip prompt for overeating.",
+        "prereqs" : ["HUNGER3"],
+        "types" : ["METABOLISM"],
+        "threshreq" : ["THRESH_CHIMERA"],
+        "category" : ["CHIMERA"],
+        "valid" : false,
+        "active" : true
+    },{
+        "type" : "mutation",
+        "id" : "HORNS",
+        "name" : "Horns",
+        "points" : 1,
+        "visibility" : 3,
+        "ugliness" : 1,
+        "description" : "You have a pair of small horns on your head.  They allow you to make a weak piercing headbutt attack.",
+        "types" : ["HORNS"],
+        "prereqs" : ["HEADBUMPS"],
+        "changes_to" : ["HORNS_CURLED", "HORNS_POINTED", "ANTLERS"],
+        "category" : ["CATTLE"],
+        "attacks" : {
+            "attack_text_u" : "You headbutt %s with your horns",
+            "attack_text_npc" : "%1$s headbutts %2$s with their horns",
+            "chance" : 20,
+            "base_damage" : [
+                { "damage_type" : "stab", "amount" : 3 },
+                { "damage_type" : "bash", "amount" : 3 }
+            ]
+        }
+    },{
+        "type" : "mutation",
+        "id" : "HORNS_CURLED",
+        "name" : "Curled Horns",
+        "points" : -3,
+        "visibility" : 8,
+        "ugliness" : 2,
+        "mixed_effect" : true,
+        "description" : "You have a pair of large curled horns, like those of a ram.  They allow you to make a strong bashing headbutt attack, but prevent wearing any headwear.",
+        "types" : ["HORNS"],
+        "prereqs" : ["HORNS"],
+        "category" : ["CHIMERA"],
+        "restricts_gear" : [ "HEAD" ],
+        "attacks" : {
+            "attack_text_u" : "You headbutt %s with your curled horns",
+            "attack_text_npc" : "%1$s headbutts %2$s with their curled horns",
+            "chance" : 20,
+            "base_damage" : { "damage_type" : "bash", "amount" : 14 }
+        }
+    },{
+        "type" : "mutation",
+        "id" : "HORNS_POINTED",
+        "name" : "Pointed Horns",
+        "points" : 1,
+        "visibility" : 8,
+        "ugliness" : 2,
+        "mixed_effect" : true,
+        "description" : "You have a pair of long, pointed horns, like those of an antelope.  They allow you to make a strong piercing headbutt attack, but prevent wearing headwear that is not made of fabric.",
+        "types" : ["HORNS"],
+        "prereqs" : ["HORNS"],
+        "restricts_gear" : [ "HEAD" ],
+        "allow_soft_gear" : true,
+        "attacks" : {
+            "attack_text_u" : "You stab %s with your pointed horns",
+            "attack_text_npc" : "%1$s stabs %2$s with their pointed horns",
+            "chance" : 22,
+            "base_damage" : { "damage_type" : "bash", "amount" : 24 }
+        }
+    },{
+        "type" : "mutation",
+        "id" : "ANTLERS",
+        "name" : "Antlers",
+        "points" : -2,
+        "visibility" : 10,
+        "ugliness" : 3,
+        "mixed_effect" : true,
+        "description" : "You have a huge rack of antlers, like those of a moose.  They allow you to make a weak headbutt attack, but prevent wearing headwear that is not made of fabric.",
+        "types" : ["HORNS"],
+        "prereqs" : ["HORNS"],
+        "restricts_gear" : [ "HEAD" ],
+        "allow_soft_gear" : true,
+        "attacks" : {
+            "attack_text_u" : "You butt %s with your antlers",
+            "attack_text_npc" : "%1$s butts %2$s with their antlers",
+            "chance" : 20,
+            "base_damage" : { "damage_type" : "bash", "amount" : 4 }
+        }
+    },{
+        "type" : "mutation",
+        "id" : "ANTENNAE",
+        "name" : "Antennae",
+        "points" : 1,
+        "visibility" : 9,
+        "ugliness" : 4,
+        "description" : "You have a pair of antennae.  They allow you to detect the presence of monsters up to a few tiles away, even if you can't see or hear them, but prevent wearing headwear that is not made of fabric.",
+        "types" : ["HORNS"],
+        "prereqs" : ["HEADBUMPS"],
+        "category" : ["INSECT"],
+        "restricts_gear" : [ "HEAD" ],
+        "allow_soft_gear" : true
+    },{
+        "type" : "mutation",
+        "id" : "FLEET2",
+        "name" : "Road-Runner",
+        "points" : 3,
+        "description" : "Your legs are extremely limber and fast-moving.  You move 30% faster on flat surfaces.",
+        "prereqs" : ["FLEET"],
+        "types" : ["RUNNING"],
+        "category" : ["BIRD"]
+    },{
+        "type" : "mutation",
+        "id" : "TAIL_STUB",
+        "name" : "Stubby Tail",
+        "points" : 0,
+        "visibility" : 1,
+        "ugliness" : 2,
+        "description" : "You have a short, stubby tail, like a rabbit's.  It serves no purpose.",
+        "types" : ["TAIL"],
+        "changes_to" : ["TAIL_LONG", "TAIL_THICK", "TAIL_FIN", "TAIL_RAT", "TAIL_RAPTOR"],
+        "category" : ["URSINE"]
+    },{
+        "type" : "mutation",
+        "id" : "TAIL_FIN",
+        "name" : "Tail Fin",
+        "points" : -1,
+        "visibility" : 4,
+        "ugliness" : 2,
+        "description" : "You have a fin-like tail.  It allows you to swim more quickly, but prevents wearing non-fabric pants.  Slightly increases wet benefits.",
+        "types" : ["TAIL"],
+        "prereqs" : ["TAIL_STUB"],
+        "category" : ["FISH"],
+        "wet_protection":[
+            { "part" : "LEG_L", "good" : 3 },
+            { "part" : "LEG_R", "good" : 3 }
+        ],
+        "restricts_gear" : [ "LEG_L", "LEG_R" ],
+        "allow_soft_gear" : true
+    },{
+        "type" : "mutation",
+        "id" : "TAIL_LONG",
+        "name" : "Long Tail",
+        "points" : 0,
+        "visibility" : 6,
+        "ugliness" : 2,
+        "description" : "You have a long, graceful tail, like that of a big cat.  It improves your balance, making your ability to dodge higher, but prevents wearing non-fabric pants.",
+        "types" : ["TAIL"],
+        "prereqs" : ["TAIL_STUB"],
+        "changes_to" : ["TAIL_FLUFFY", "TAIL_STING", "TAIL_CLUB", "TAIL_CATTLE", "TAIL_RAT"],
+        "category" : ["FELINE"],
+        "restricts_gear" : [ "LEG_L", "LEG_R" ],
+        "allow_soft_gear" : true
+    },{
+        "type" : "mutation",
+        "id" : "TAIL_CATTLE",
+        "name" : "Cattle Tail",
+        "points" : -1,
+        "visibility" : 6,
+        "ugliness" : 2,
+        "description" : "You have a long tail with a tuft on the end.  You find yourself instinctively swatting away flies with it, though it's not as effective at balancing you as you'd like.  Prevents wearing non-fabric pants.",
+        "types" : ["TAIL"],
+        "prereqs" : ["TAIL_LONG"],
+        "category" : ["CATTLE"],
+        "restricts_gear" : [ "LEG_L", "LEG_R" ],
+        "allow_soft_gear" : true
+    },{
+        "type" : "mutation",
+        "id" : "TAIL_RAT",
+        "name" : "Rodent Tail",
+        "points" : 1,
+        "visibility" : 6,
+        "ugliness" : 4,
+        "description" : "You have a long but hairless tail.  It's a pretty effective balancing aid, but does look, uh, ratty.  Prevents wearing non-fabric pants.",
+        "types" : ["TAIL"],
+        "prereqs" : ["TAIL_LONG", "TAIL_STUB"],
+        "category" : ["RAT", "MOUSE"],
+        "restricts_gear" : [ "LEG_L", "LEG_R" ],
+        "allow_soft_gear" : true
+    },{
+        "type" : "mutation",
+        "id" : "TAIL_THICK",
+        "name" : "Thick Tail",
+        "points" : 1,
+        "visibility" : 8,
+        "ugliness" : 2,
+        "description" : "You have a long, thick, lizardlike tail.  It helps you balance a bit but also makes a serviceable whip.  Prevents wearing non-fabric pants.",
+        "types" : ["TAIL"],
+        "prereqs" : ["TAIL_STUB"],
+        "changes_to" : ["TAIL_CLUB"],
+        "category" : ["LIZARD"],
+        "restricts_gear" : [ "LEG_L", "LEG_R" ],
+        "allow_soft_gear" : true,
+        "attacks" : {
+            "attack_text_u" : "You whap %s with your tail",
+            "attack_text_npc" : "%1$s whaps %2$s with their tail",
+            "chance" : 20,
+            "base_damage" : { "damage_type" : "stab", "amount" : 8 }
+        }
+    },{
+        "type" : "mutation",
+        "id" : "TAIL_RAPTOR",
+        "name" : "Raptor Tail",
+        "points" : 1,
+        "visibility" : 8,
+        "ugliness" : 2,
+        "description" : "You have a long and semi-stiff lizardlike tail.  You can't effectively lash it in combat, but it significantly improves your balance.  Prevents wearing non-fabric pants.",
+        "types" : ["TAIL"],
+        "prereqs" : ["TAIL_STUB"],
+        "category" : ["RAPTOR"],
+        "restricts_gear" : [ "LEG_L", "LEG_R" ],
+        "allow_soft_gear" : true
+    },{
+        "type" : "mutation",
+        "id" : "TAIL_FLUFFY",
+        "name" : "Fluffy Tail",
+        "points" : 1,
+        "visibility" : 7,
+        "description" : "You have a long, fluffy-furred tail.  It greatly improves your balance, making your ability to dodge much higher.  Prevents wearing non-fabric pants.",
+        "types" : ["TAIL"],
+        "prereqs" : ["TAIL_LONG"],
+        "category" : ["BEAST", "LUPINE"],
+        "restricts_gear" : [ "LEG_L", "LEG_R" ],
+        "allow_soft_gear" : true,
+        "social_modifiers" : {
+            "lie": -20 ,
+            "persuade": 10
+        }
+    },{
+        "type" : "mutation",
+        "id" : "TAIL_STING",
+        "name" : "Spiked Tail",
+        "points" : 0,
+        "visibility" : 6,
+        "ugliness" : 3,
+        "description" : "You have a long tail that ends in a vicious stinger, like that of a scorpion.  It does not improve your balance at all, but allows for a powerful piercing attack.  Prevents wearing non-fabric pants.",
+        "types" : ["TAIL"],
+        "prereqs" : ["TAIL_LONG"],
+        "category" : ["INSECT"],
+        "restricts_gear" : [ "LEG_L", "LEG_R" ],
+        "allow_soft_gear" : true,
+        "attacks" : {
+            "attack_text_u" : "You sting %s with your tail",
+            "attack_text_npc" : "%1$s stings %2$s with their tail",
+            "chance" : 20,
+            "base_damage" : { "damage_type" : "stab", "amount" : 20 }
+        }
+    },{
+        "type" : "mutation",
+        "id" : "TAIL_CLUB",
+        "name" : "Club Tail",
+        "points" : 0,
+        "visibility" : 7,
+        "ugliness" : 2,
+        "description" : "You have a long tail that ends in a heavy, bony club.  It does not improve your balance at all, but allows for a powerful bashing attack.  Prevents wearing non-fabric pants.",
+        "types" : ["TAIL"],
+        "prereqs" : ["TAIL_THICK"],
+        "category" : ["CHIMERA"],
+        "restricts_gear" : [ "LEG_L", "LEG_R" ],
+        "allow_soft_gear" : true,
+        "attacks" : {
+            "attack_text_u" : "You club %s with your tail",
+            "attack_text_npc" : "%1$s clubs %2$s with their tail",
+            "chance" : 20,
+            "base_damage" : { "damage_type" : "stab", "amount" : 18 }
+        }
+    },{
+        "type" : "mutation",
+        "id" : "HIBERNATE",
+        "name" : "Hibernation",
+        "points" : 3,
+        "description" : "You've developed the ability to stockpile calories and then sleep for extended periods of time.",
+        "valid" : false,
+        "prereqs" : ["HEAVYSLEEPER2"],
+        "prereqs2" : ["FAT"],
+        "threshreq" : ["THRESH_URSINE"],
+        "category" : ["URSINE"],
+        "active"     :    true,
+        "cost"       :    0
+    },{
+        "type" : "mutation",
+        "id" : "MUT_TOUGH",
+        "name" : "Resilient",
+        "points" : 2,
+        "description" : "You can survive injuries that would incapacitate humans: you get a 20% bonus to all hit points.  Stacks with Tough, etc.",
+        "social_modifiers" : {
+            "intimidate" : 2
+        },
+        "prereqs" : ["LARGE_OK", "HUGE_OK", "STR_UP_3", "STR_UP_4", "MASOCHIST_MED"],
+        "threshreq" : ["THRESH_URSINE", "THRESH_CATTLE", "THRESH_CHIMERA", "THRESH_MEDICAL", "THRESH_LIZARD", "THRESH_BEAST"],
+        "cancels" : ["FLIMSY", "FLIMSY2", "FLIMSY3", "GLASSJAW"],
+        "changes_to" : ["MUT_TOUGH2"],
+        "category" : ["URSINE", "CATTLE", "CHIMERA","BEAST", "LIZARD", "MEDICAL"],
+        "hp_modifier_secondary" : 0.2
+    },{
+        "type" : "mutation",
+        "id" : "MUT_TOUGH2",
+        "name" : "Solidly Built",
+        "points" : 3,
+        "description" : "Not much scares you.  You get a 30% bonus to all hit points.  Stacks with Tough, etc.",
+        "social_modifiers" : {
+            "intimidate" : 3
+        },
+        "valid" : false,
+        "prereqs" : ["MUT_TOUGH"],
+        "threshreq" : ["THRESH_URSINE", "THRESH_CATTLE", "THRESH_CHIMERA", "THRESH_MEDICAL"],
+        "cancels" : ["FLIMSY", "FLIMSY2", "FLIMSY3", "GLASSJAW"],
+        "changes_to" : ["MUT_TOUGH3"],
+        "category" : ["URSINE", "CATTLE", "CHIMERA", "MEDICAL"],
+        "hp_modifier_secondary" : 0.3
+    },{
+        "type" : "mutation",
+        "id" : "MUT_TOUGH3",
+        "name" : "TAAANK",
+        "points" : 4,
+        "description" : "You can simply take the punishment from lesser beings and keep going.  You get a 40% bonus to all hit points.  Stacks with Tough, etc.",
+        "social_modifiers" : {
+            "intimidate" : 4
+        },
+        "valid" : false,
+        "prereqs" : ["MUT_TOUGH2"],
+        "threshreq" : ["THRESH_URSINE", "THRESH_CATTLE"],
+        "cancels" : ["FLIMSY", "FLIMSY2", "FLIMSY3", "GLASSJAW"],
+        "category" : ["URSINE", "CATTLE"],
+        "hp_modifier_secondary" : 0.4
+    },{
+        "type" : "mutation",
+        "id" : "PAINREC1",
+        "name" : "Pain Recovery",
+        "points" : 3,
+        "description" : "You recover from pain slightly faster than normal.",
+        "changes_to" : ["PAINREC2"]
+    },{
+        "type" : "mutation",
+        "id" : "PAINREC2",
+        "name" : "Quick Pain Recovery",
+        "points" : 5,
+        "description" : "You recover from pain faster than normal.",
+        "prereqs" : ["PAINREC1"],
+        "changes_to" : ["PAINREC3"]
+    },{
+        "type" : "mutation",
+        "id" : "PAINREC3",
+        "name" : "Very Quick Pain Recovery",
+        "points" : 8,
+        "description" : "You recover from pain much faster than normal.",
+        "prereqs" : ["PAINREC2"],
+        "category" : ["MEDICAL"]
+    },{
+        "type" : "mutation",
+        "id" : "MASOCHIST_MED",
+        "name" : "Pain Junkie",
+        "points" : 4,
+        "visibility" : 3,
+        "ugliness" : 2,
+        "description" : "You've developed a serious appetite for pain, and take pride in your scars.",
+        "valid" : false,
+        "prereqs" : ["MASOCHIST", "PAINRESIST", "ADDICTIVE"],
+        "prereqs2" : ["PAINREC2", "PAINREC3"],
+        "threshreq" : ["THRESH_MEDICAL"],
+        "leads_to" : ["MUT_TOUGH"],
+        "changes_to" : ["CENOBITE"],
+        "//" : "MASOCHIST_MED and NOPAIN don't cancel each other.  By design.  Poor painless folks...",
+        "category" : ["MEDICAL"]
+    },{
+        "type" : "mutation",
+        "id" : "CENOBITE",
+        "name" : "Cenobite",
+        "points" : 6,
+        "visibility" : 4,
+        "ugliness" : 10,
+        "description" : "You positively adore pain, in all its varied forms.",
+        "valid" : false,
+        "purifiable" : false,
+        "prereqs" : ["MASOCHIST_MED"],
+        "prereqs2" : ["PAINREC3", "ADDICTIVE"],
+        "threshreq" : ["THRESH_MEDICAL"],
+        "//" : "CENOBITE and NOPAIN also don't cancel each other.  By design.  Poor painless cenobites...",
+        "category" : ["MEDICAL"]
+    },{
+        "type" : "mutation",
+        "id" : "NOPAIN",
+        "name" : "Deadened",
+        "points" : 2,
+        "description" : "Nothing hurts any more.  Those bites tickle and the wounds itch a bit, but that's it.",
+        "valid" : false,
+        "purifiable" : false,
+        "prereqs" : ["MASOCHIST", "PAINRESIST"],
+        "prereqs2" : ["PAINREC3"],
+        "cancels" : ["MORE_PAIN", "MORE_PAIN2", "MORE_PAIN3"],
+        "threshreq" : ["THRESH_MEDICAL"],
+        "//" : "MASOCHIST_MED, CENOBITE, and NOPAIN don't cancel each other.  By design.  Poor painless people...",
+        "category" : ["MEDICAL"]
+    },{
+        "type" : "mutation",
+        "id" : "MORE_PAIN",
+        "name" : "Pain Sensitive",
+        "points" : -2,
+        "description" : "For some reason things always seem to hurt you more.  Pain dealt to you is increased by 25%.",
+        "starting_trait" : true,
+        "//" : "The MORE_PAIN mutations will always increase the pain you receive by at least 1.",
+        "cancels" : ["PAINRESIST", "NOPAIN"],
+        "changes_to" : ["MORE_PAIN2"]
+    },{
+        "type" : "mutation",
+        "id" : "MORE_PAIN2",
+        "name" : "Hyperalgesia",
+        "points" : -3,
+        "description" : "Your body experiences pain out of proportion to the physical causes.  Pain dealt to you is increased by 50%.",
+        "prereqs" : ["MORE_PAIN"],
+        "cancels" : ["PAINRESIST", "NOPAIN"],
+        "changes_to" : ["MORE_PAIN3"]
+    },{
+        "type" : "mutation",
+        "id" : "MORE_PAIN3",
+        "name" : "Extreme Hyperalgesia",
+        "points" : -5,
+        "description" : "Your body reacts cripplingly to any source of pain.  Pain dealt to you is doubled.",
+        "prereqs" : ["MORE_PAIN2"],
+        "cancels" : ["PAINRESIST", "NOPAIN"]
+    },{
+        "type" : "mutation",
+        "id" : "PRED1",
+        "name" : "Culler",
+        "points" : 2,
+        "description" : "You've had a revelation: by killing the weaker creatures, who would only die anyway, you preserve resources for those better able to survive.  You are less bothered by the deaths of others: their own weakness invited these fates upon them.",
+        "purifiable" : false,
+        "changes_to" : ["PRED2"],
+        "prereqs" : ["CARNIVORE"],
+        "threshreq" : ["THRESH_BEAST", "THRESH_RAPTOR", "THRESH_CHIMERA", "THRESH_LUPINE", "THRESH_FELINE", "THRESH_URSINE", "THRESH_LIZARD", "THRESH_SPIDER"],
+        "cancels" : ["PACIFIST"],
+        "category" : ["BEAST", "RAPTOR", "CHIMERA", "LUPINE", "FELINE", "URSINE", "LIZARD", "SPIDER"]
+    },{
+        "type" : "mutation",
+        "id" : "PRED2",
+        "name" : "Hunter",
+        "points" : 3,
+        "description" : "Your brain has a lot more in common with a predatory animal than a human, making it easier to control misplaced reactions to the death of your prey.  Additionally, combat skills, which you use to hunt, are easier to learn and maintain.",
+        "social_modifiers" : {
+            "intimidate" : 3
+        },
+        "purifiable" : false,
+        "prereqs" : ["CARNIVORE", "THRESH_URSINE"],
+        "prereqs2" : ["PRED1"],
+        "changes_to" : ["PRED3"],
+        "threshreq" : ["THRESH_BEAST", "THRESH_RAPTOR", "THRESH_CHIMERA", "THRESH_LUPINE", "THRESH_FELINE", "THRESH_URSINE", "THRESH_LIZARD", "THRESH_SPIDER"],
+        "cancels" : ["PACIFIST"],
+        "category" : ["BEAST", "RAPTOR", "CHIMERA", "LUPINE", "FELINE", "URSINE", "LIZARD", "SPIDER"]
+    },{
+        "type" : "mutation",
+        "id" : "PRED3",
+        "name" : "Predator",
+        "points" : 3,
+        "description" : "You consider yourself something other than human and no longer empathize with them.  Combat skills are easy to learn and maintain, but your critical thinking, so characteristic to these creatures, suffers.",
+        "social_modifiers" : {
+            "intimidate" : 4
+        },
+        "valid" : false,
+        "purifiable" : false,
+        "prereqs" : ["CARNIVORE", "THRESH_URSINE"],
+        "prereqs2" : ["PRED2"],
+        "leads_to" : ["SAPIOVORE"],
+        "changes_to" : ["PRED4"],
+        "threshreq" : ["THRESH_BEAST", "THRESH_RAPTOR", "THRESH_CHIMERA", "THRESH_LUPINE", "THRESH_FELINE", "THRESH_URSINE", "THRESH_LIZARD", "THRESH_SPIDER"],
+        "cancels" : ["PACIFIST"],
+        "category" : ["BEAST", "RAPTOR", "CHIMERA", "LUPINE", "FELINE", "URSINE", "LIZARD", "SPIDER"],
+        "passive_mods" : {
+            "int_mod" : -1
+        }
+    },{
+        "type" : "mutation",
+        "id" : "PRED4",
+        "name" : "Apex Predator",
+        "points" : 2,
+        "description" : "Your mind and brain have adapted to your new place in the world: as one on top of the food chain.  You can effortlessly master and maintain combat skills, but your critical thinking has atrophied further.",
+        "social_modifiers" : {
+            "intimidate" : 5
+        },
+        "valid" : false,
+        "purifiable" : false,
+        "prereqs" : ["CARNIVORE", "THRESH_URSINE"],
+        "prereqs2" : ["PRED3"],
+        "cancels" : ["PACIFIST"],
+        "threshreq" : ["THRESH_BEAST", "THRESH_RAPTOR", "THRESH_CHIMERA", "THRESH_URSINE"],
+        "category" : ["BEAST", "RAPTOR", "CHIMERA", "URSINE"],
+        "passive_mods" : {
+            "int_mod" : -3
+        }
+    },{
+        "type" : "mutation",
+        "id" : "SAPIOVORE",
+        "name" : "Sapiovore",
+        "points" : 1,
+        "description" : "The hairless apes make as good eating as any other meat.",
+        "social_modifiers" : {
+            "persuade": -20,
+            "lie": -20,
+            "intimidate" : 6
+        },
+        "valid" : false,
+        "purifiable" : false,
+        "prereqs" : ["CARNIVORE"],
+        "prereqs2" : ["PRED3", "PRED4"],
+        "threshreq" : ["THRESH_BEAST", "THRESH_RAPTOR", "THRESH_CHIMERA", "THRESH_URSINE", "THRESH_LIZARD", "THRESH_SPIDER"],
+        "category" : ["BEAST", "RAPTOR", "CHIMERA", "URSINE", "LIZARD", "SPIDER"],
+        "flags" : ["CANNIBAL"]
+    },{
+        "type" : "mutation",
+        "id" : "M_DEFENDER",
+        "name" : "Mycus Defender",
+        "points" : 4,
+        "description" : "From time to time the Mycus requires protection from non-Mycus that, for whatever reason, wish it ill.  We have adapted to better carry out this task - our fibers will grow strong and resilient when such threats present themselves to us.",
+        "valid" : false,
+        "purifiable" : false,
+        "cancels" : ["ADRENALINE"],
+        "prereqs" : ["M_SKIN"],
+        "prereqs2" : ["M_DEPENDENT"],
+        "threshreq" : ["THRESH_MYCUS"],
+        "category" : ["MYCUS"]
+    },{
+        "type" : "mutation",
+        "id" : "WINGS_BIRD",
+        "name" : "Bird Wings",
+        "points" : 2,
+        "visibility" : 4,
+        "ugliness" : 2,
+        "description" : "You have a pair of large, feathered wings.  Your body is too heavy to be able to fly, but you can use them to slow your descent during a fall, and will not take falling damage under any circumstances.",
+        "types" : ["WINGS"],
+        "prereqs" : ["WINGS_STUB"],
+        "category" : ["BIRD"]
+    },{
+        "type" : "mutation",
+        "id" : "WINGS_INSECT",
+        "name" : "Insect Wings",
+        "points" : 1,
+        "visibility" : 4,
+        "ugliness" : 4,
+        "description" : "You have a pair of large, translucent wings.  They are too small to lift you, but are powerful enough to greatly speed your movement, with some effort and noise.",
+        "types" : ["WINGS"],
+        "prereqs" : ["WINGS_STUB"],
+        "category" : ["INSECT"],
+        "active"     :    true,
+        "cost"       :    20,
+        "time"       :    10,
+        "fatigue"    :    true,
+        "hunger" : true,
+        "thirst" : true
+    },{
+        "type" : "mutation",
+        "id" : "MOUTH_TENTACLES",
+        "name" : "Mouth Tentacles",
+        "points" : 1,
+        "visibility" : 8,
+        "ugliness" : 5,
+        "description" : "A set of tentacles surrounds your mouth.  They allow you to eat twice as fast.  Slightly decreases wet penalties.",
+        "prereqs" : ["MOUTH_FLAPS"],
+        "cancels" : ["MANDIBLES"],
+        "category" : ["CEPHALOPOD"],
+        "wet_protection" : [
+            { "part" : "MOUTH", "neutral" : 4 }
+        ]
+    },{
+        "type" : "mutation",
+        "id" : "MANDIBLES",
+        "name" : "Mandibles",
+        "points" : 1,
+        "visibility" : 8,
+        "ugliness" : 6,
+        "mixed_effect" : true,
+        "description" : "A set of insect-like mandibles have grown around your mouth.  They allow you to eat faster and provide a slicing unarmed attack, but prevent wearing mouthwear.  Slightly reduces wet effects.",
+        "types" : ["TEETH", "MUZZLE"],
+        "prereqs" : ["MOUTH_FLAPS"],
+        "changes_to" : ["FANGS_SPIDER"],
+        "cancels" : ["MOUTH_TENTACLES"],
+        "category" : ["INSECT", "SPIDER"],
+        "wet_protection" : [
+            { "part" : "MOUTH", "ignored" : 1 }
+        ],
+        "restricts_gear" : [ "MOUTH" ],
+        "destroys_gear" : true,
+        "attacks" : {
+            "attack_text_u" : "You bite %s with your fangs",
+            "attack_text_npc" : "%1$s bites %2$s with their fangs",
+            "blocker_mutations" : [ "FANGS_SPIDER" ],
+            "body_part" : "MOUTH",
+            "chance" : 22,
+            "base_damage" : { "damage_type" : "cut", "amount" : 12 }
+        }
+    },{
+        "type" : "mutation",
+        "id" : "FANGS_SPIDER",
+        "name" : "Folding Fangs",
+        "points" : 2,
+        "visibility" : 6,
+        "ugliness" : 6,
+        "description" : "Your mandibles have developed extensible fangs, allowing you to bite quickly or ensure your venom goes home, as desired.",
+        "types" : ["TEETH", "MUZZLE"],
+        "cancels" : ["MOUTH_TENTACLES"],
+        "prereqs" : ["MANDIBLES"],
+        "prereqs2" : ["POISONOUS", "POISONOUS2"],
+        "threshreq" : ["THRESH_SPIDER"],
+        "category" : ["SPIDER"],
+        "wet_protection" : [
+            { "part" : "MOUTH", "ignored" : 1 }
+        ],
+        "attacks" : {
+            "attack_text_u" : "You bite %s with your fangs",
+            "attack_text_npc" : "%1$s bites %2$s with their fangs",
+            "blocker_mutations" : [ "MANDIBLES" ],
+            "body_part" : "MOUTH",
+            "chance" : 22,
+            "base_damage" : { "damage_type" : "stab", "amount" : 15 }
+        }
+    },{
+        "type" : "mutation",
+        "id" : "CANINE_EARS",
+        "name" : "Canine Ears",
+        "points" : 1,
+        "visibility" : 4,
+        "ugliness" : 1,
+        "description" : "Your ears have extended into long, pointed ones, like those of a canine.  They enhance your hearing, allowing you to hear at greater distances.",
+        "types" : ["EARS"],
+        "category" : ["BEAST", "CATTLE", "CHIMERA"],
+        "changes_to" : ["LUPINE_EARS"]
+    },{
+        "type" : "mutation",
+        "id" : "LUPINE_EARS",
+        "name" : "Lupine Ears",
+        "points" : 1,
+        "visibility" : 4,
+        "ugliness" : 1,
+        "description" : "Your hearing has evolved further and is now on par with wolves.  You can hear things significantly farther away.",
+        "types" : ["EARS"],
+        "category" : ["LUPINE"]
+    },{
+        "type" : "mutation",
+        "id" : "FELINE_EARS",
+        "name" : "Feline Ears",
+        "points" : 1,
+        "visibility" : 4,
+        "description" : "Your ears have extended into long, pointed, velvety ones, like those of a feline.  You find it easier to tune in on sounds from afar.",
+        "types" : ["EARS"],
+        "category" : ["FELINE"]
+    },{
+        "type" : "mutation",
+        "id" : "URSINE_EARS",
+        "name" : "Ursine Ears",
+        "points" : 1,
+        "visibility" : 4,
+        "ugliness" : 1,
+        "description" : "Your ears have grown longer and rounder, much like those of a bear.  You can hear things a little farther away.",
+        "types" : ["EARS"],
+        "category" : ["URSINE"]
+    },{
+        "type" : "mutation",
+        "id" : "ELFA_EARS",
+        "name" : "Pointed Ears",
+        "points" : 0,
+        "visibility" : 4,
+        "ugliness" : 1,
+        "description" : "Your upper earlobes have grown noticeably higher.  Fortunately, they don't get in the way of your headgear, much.  Unfortunately, they also don't seem to help your hearing any.",
+        "valid" : false,
+        "types" : ["EARS"],
+        "category" : ["ELFA"]
+    },{
+        "type" : "mutation",
+        "id" : "MOUSE_EARS",
+        "name" : "Rodent Ears",
+        "points" : 1,
+        "visibility" : 8,
+        "ugliness" : 1,
+        "description" : "Your ears are huge, round, and gray!  They're rather fascinating, and help you hear from a much greater distance.",
+        "valid" : false,
+        "types" : ["EARS"],
+        "category" : ["MOUSE", "RAT"]
+    },{
+        "type" : "mutation",
+        "id" : "WEB_WALKER",
+        "name" : "Web Walker",
+        "points" : 1,
+        "description" : "Your body excretes very fine amounts of a chemical which prevents you from sticking to webs.  Walking through webs does not affect you at all.",
+        "leads_to" : ["WEB_WEAVER"],
+        "category" : ["SPIDER"]
+    },{
+        "type" : "mutation",
+        "id" : "WEB_SPINNER",
+        "name" : "Web Spinner",
+        "points" : -3,
+        "description" : "Your body produces and anchors webbing.  Too bad you can't seem to control the process.  There is a chance that you will leave webs in your wake.",
+        "prereqs" : ["WEB_WALKER"],
+        "threshreq" : ["THRESH_SPIDER"],
+        "cancels" : ["SLIMY"],
+        "changes_to" : ["WEB_WEAVER"],
+        "category" : ["SPIDER"]
+    },{
+        "type" : "mutation",
+        "id" : "WEB_WEAVER",
+        "name" : "Web Weaver",
+        "points" : 2,
+        "description" : "You've developed the necessary anatomy and techniques to control your web-generation.  Activate this to start or stop weaving webs.",
+        "prereqs" : ["WEB_SPINNER"],
+        "threshreq" : ["THRESH_SPIDER"],
+        "cancels" : ["SLIMY"],
+        "category" : ["SPIDER"],
+        "active"     :    true,
+        "cost"       :    8,
+        "time"       :    100,
+        "hunger"     :    true,
+        "thirst"     :    true
+    },{
+        "type" : "mutation",
+        "id" : "WEB_RAPPEL",
+        "name" : "Web Diver",
+        "points" : 2,
+        "description" : "Your webbing is easily strong enough to support your weight.  You'll use it to descend down any sheer drops you may encounter.",
+        "prereqs" : ["WEB_WEAVER"],
+        "threshreq" : ["THRESH_SPIDER"],
+        "category" : ["SPIDER"]
+    },{
+        "type" : "mutation",
+        "id" : "WEB_ROPE",
+        "name" : "Rope Webs",
+        "points" : 3,
+        "description" : "With spinnerets like THESE, who needs rope?!  Activate to produce rope.",
+        "prereqs" : ["WEB_WEAVER"],
+        "threshreq" : ["THRESH_SPIDER"],
+        "category" : ["SPIDER"],
+        "active"     :    true,
+        "cost"       :    30,
+        "hunger"     :    true,
+        "thirst"     :    true,
+        "spawn_item" : { "type": "rope_30", "message": "You spin a rope from your silk." }
+    },{
+        "type" : "mutation",
+        "id" : "WHISKERS",
+        "name" : "Whiskers",
+        "points" : 1,
+        "visibility" : 3,
+        "ugliness" : 1,
+        "description" : "You have a handsome set of feline whiskers around your mouth.  These make you more aware of vibrations in the air, and improve your ability to dodge very slightly.",
+        "types" : ["WHISKERS"],
+        "category" : ["FELINE"]
+    },{
+        "type" : "mutation",
+        "id" : "WHISKERS_RAT",
+        "name" : "Wiry Whiskers",
+        "points" : 2,
+        "visibility" : 3,
+        "ugliness" : 1,
+        "description" : "You have a set of prominent rodent-like whiskers around your mouth.  These make you more aware of vibrations in the air, and improve your ability to dodge slightly.",
+        "types" : ["WHISKERS"],
+        "prereqs" : ["MUZZLE_RAT"],
+        "category" : ["RAT", "MOUSE"]
+    },{
+        "type" : "mutation",
+        "id" : "FAT",
+        "name" : "Fat Deposits",
+        "points" : -1,
+        "visibility" : 1,
+        "ugliness" : 1,
+        "bodytemp_modifiers" : [200, 200],
+        "mixed_effect" : true,
+        "description" : "You've put on some additional weight around your body.  It slows you down a little, but helps your swimming and warmth.",
+        "prereqs" : ["STR_UP", "STR_UP_2", "STR_UP_3", "STR_UP_4"],
+        "leads_to" : ["HIBERNATE"],
+        "category" : ["URSINE"],
+        "armor" : [ { "parts" : "ALL", "bash" : 1 } ]
+    },{
+        "type" : "mutation",
+        "id" : "LARGE",
+        "name" : "Inconveniently Large",
+        "points" : 0,
+        "visibility" : 1,
+        "ugliness" : 1,
+        "mixed_effect" : true,
+        "encumbrance_always" : [
+            [ "TORSO", 10 ],
+            [ "ARM_L", 10 ],
+            [ "ARM_R", 10 ]
+        ],
+        "description" : "You have grown noticeably taller and broader.  Much of it is useful muscle mass (Strength +2), but you find it throws off your balance and you get in your own way (+10 torso and arm encumbrance).",
+        "prereqs" : ["STR_UP", "STR_UP_2", "STR_UP_3", "STR_UP_4"],
+        "cancels" : ["SMALL", "SMALL2"],
+        "changes_to": ["LARGE_OK", "HUGE"],
+        "category" : ["URSINE", "CATTLE", "LIZARD"],
+        "passive_mods" : {
+            "str_mod" : 2
+        }
+    },{
+        "type" : "mutation",
+        "id" : "LARGE_OK",
+        "name" : "Large",
+        "points" : 2,
+        "visibility" : 1,
+        "description" : "You carry your rugged body with the dignity you deserve.  Strength +2.",
+        "prereqs" : ["LARGE"],
+        "prereqs2" : ["STR_UP", "STR_UP_2", "STR_UP_3", "STR_UP_4"],
+        "cancels" : ["SMALL", "SMALL2"],
+        "threshreq" : ["THRESH_URSINE", "THRESH_CATTLE", "THRESH_LIZARD"],
+        "changes_to": ["HUGE"],
+        "leads_to" : ["MUT_TOUGH"],
+        "category" : ["URSINE", "CATTLE", "LIZARD"],
+        "passive_mods" : {
+            "str_mod" : 2
+        }
+    },{
+        "type" : "mutation",
+        "id" : "HUGE",
+        "name" : "Freakishly Huge",
+        "points" : -2,
+        "visibility" : 4,
+        "ugliness" : 4,
+        "mixed_effect" : true,
+        "description" : "You have grown even more massive, to the point where you cannot usefully fit into human-sized clothing or vehicles.  Much of it is powerful muscle mass (Strength +4), but it's a real pain to haul around.",
+        "prereqs" : ["LARGE", "LARGE_OK"],
+        "prereqs2" : ["STR_UP_3", "STR_UP_4"],
+        "cancels" : ["SMALL", "SMALL2"],
+        "changes_to": ["HUGE_OK"],
+        "category" : ["URSINE", "CATTLE"],
+        "passive_mods" : {
+            "str_mod" : 4
+        },
+        "hp_adjustment": -6,
+        "fatigue_modifier": 0.15,
+        "restricts_gear" : [ "TORSO", "LEG_L", "LEG_R", "ARM_L", "ARM_R", "HAND_L", "HAND_R", "HEAD", "FOOT_L", "FOOT_R" ],
+        "destroys_gear" : true
+    },{
+        "type" : "mutation",
+        "id" : "HUGE_OK",
+        "name" : "Huge",
+        "points" : 2,
+        "visibility" : 4,
+        "ugliness" : 3,
+        "mixed_effect" : true,
+        "description" : "Your cardiovascular system has caught up with your muscular physique, so who needs pathetic human cars?  Strength +4.",
+        "prereqs" : ["HUGE"],
+        "prereqs2" : ["STR_UP_3", "STR_UP_4"],
+        "cancels" : ["SMALL", "SMALL2"],
+        "threshreq" : ["THRESH_URSINE", "THRESH_CATTLE"],
+        "leads_to" : ["MUT_TOUGH"],
+        "category" : ["URSINE", "CATTLE"],
+        "passive_mods" : {
+            "str_mod" : 4
+        },
+        "restricts_gear" : [ "TORSO", "LEG_L", "LEG_R", "ARM_L", "ARM_R", "HAND_L", "HAND_R", "HEAD", "FOOT_L", "FOOT_R" ],
+        "destroys_gear" : true
+    },{
+        "type" : "mutation",
+        "id" : "STR_UP",
+        "name" : "Strong",
+        "points" : 1,
+        "description" : "Your muscles are a little stronger.  Strength + 1",
+        "changes_to" : ["STR_UP_2"],
+        "category" : ["INSECT", "ELFA", "RAPTOR"],
+        "passive_mods" : {
+            "str_mod" : 1
+        }
+    },{
+        "type" : "mutation",
+        "id" : "STR_UP_2",
+        "name" : "Very Strong",
+        "points" : 2,
+        "description" : "Your muscles are stronger.  Strength + 2",
+        "prereqs" : ["STR_UP"],
+        "changes_to" : ["STR_UP_3", "STR_ALPHA"],
+        "category" : ["LIZARD", "CATTLE", "PLANT", "ALPHA"],
+        "passive_mods" : {
+            "str_mod" : 2
+        }
+    },{
+        "type" : "mutation",
+        "id" : "STR_UP_3",
+        "name" : "Extremely Strong",
+        "points" : 4,
+        "visibility" : 1,
+        "description" : "Your muscles are much stronger.  Strength + 4",
+        "prereqs" : ["STR_UP_2"],
+        "changes_to" : ["STR_UP_4"],
+        "leads_to" : ["MUT_TOUGH"],
+        "category" : ["CHIMERA", "LUPINE", "TROGLOBITE"],
+        "passive_mods" : {
+            "str_mod" : 4
+        }
+    },{
+        "type" : "mutation",
+        "id" : "STR_UP_4",
+        "name" : "Insanely Strong",
+        "points" : 7,
+        "visibility" : 2,
+        "ugliness" : 2,
+        "description" : "Your muscles are noticeably bulging.  Strength + 7",
+        "prereqs" : ["STR_UP_3"],
+        "leads_to" : ["MUT_TOUGH"],
+        "threshreq" : ["THRESH_BEAST", "THRESH_URSINE"],
+        "category" : ["BEAST", "URSINE"],
+        "passive_mods" : {
+            "str_mod" : 7
+        }
+    },{
+        "type" : "mutation",
+        "id" : "STR_ALPHA",
+        "name" : "Prime Strength",
+        "points" : 6,
+        "description" : "Your muscles are perfectly developed.",
+        "valid" : false,
+        "prereqs" : ["STR_UP_2"],
+        "threshreq" : ["THRESH_ALPHA"],
+        "category" : ["ALPHA"],
+        "passive_mods" : {
+            "str_mod" : 2
+        }
+    },{
+        "type" : "mutation",
+        "id" : "DEX_UP",
+        "name" : "Dextrous",
+        "points" : 1,
+        "description" : "You are a little nimbler.  Dexterity + 1",
+        "changes_to" : ["DEX_UP_2", "DEX_ALPHA"],
+        "category" : ["INSECT", "SLIME", "ALPHA"],
+        "passive_mods" : {
+            "dex_mod" : 1
+        }
+    },{
+        "type" : "mutation",
+        "id" : "DEX_UP_2",
+        "name" : "Very Dextrous",
+        "points" : 2,
+        "description" : "You are nimbler.  Dexterity + 2",
+        "prereqs" : ["DEX_UP"],
+        "changes_to" : ["DEX_UP_3"],
+        "category" : ["LIZARD", "SPIDER", "CHIMERA", "RAPTOR", "MOUSE"],
+        "passive_mods" : {
+            "dex_mod" : 2
+        }
+    },{
+        "type" : "mutation",
+        "id" : "DEX_UP_3",
+        "name" : "Extremely Dextrous",
+        "points" : 3,
+        "description" : "You are nimble and quick.  Dexterity + 4",
+        "prereqs" : ["DEX_UP_2"],
+        "changes_to" : ["DEX_UP_4"],
+        "category" : ["BIRD", "ELFA", "FELINE"],
+        "passive_mods" : {
+            "dex_mod" : 4
+        }
+    },{
+        "type" : "mutation",
+        "id" : "DEX_UP_4",
+        "name" : "Insanely Dextrous",
+        "points" : 4,
+        "description" : "You are much nimbler than before.  Dexterity + 7",
+        "prereqs" : ["DEX_UP_3"],
+        "threshreq" : ["THRESH_CEPHALOPOD", "THRESH_FISH"],
+        "category" : ["CEPHALOPOD", "FISH"],
+        "passive_mods" : {
+            "dex_mod" : 7
+        }
+    },{
+        "type" : "mutation",
+        "id" : "DEX_ALPHA",
+        "name" : "Prime Dexterity",
+        "points" : 6,
+        "description" : "You're perfectly coordinated.",
+        "valid" : false,
+        "prereqs" : ["DEX_UP"],
+        "threshreq" : ["THRESH_ALPHA"],
+        "category" : ["ALPHA"],
+        "passive_mods" : {
+            "dex_mod" : 1
+        }
+    },{
+        "type" : "mutation",
+        "id" : "INT_UP",
+        "name" : "Smart",
+        "points" : 1,
+        "description" : "You are a little smarter.  Intelligence + 1",
+        "changes_to" : ["INT_UP_2", "INT_ALPHA", "INT_SLIME"],
+        "category" : ["SLIME", "ALPHA"],
+        "passive_mods" : {
+            "int_mod" : 1
+        }
+    },{
+        "type" : "mutation",
+        "id" : "INT_UP_2",
+        "name" : "Very Smart",
+        "points" : 2,
+        "description" : "You are smarter.  Intelligence + 2",
+        "prereqs" : ["INT_UP"],
+        "changes_to" : ["INT_UP_3"],
+        "passive_mods" : {
+            "int_mod" : 2
+        }
+    },{
+        "type" : "mutation",
+        "id" : "INT_UP_3",
+        "name" : "Extremely Smart",
+        "points" : 3,
+        "visibility" : 1,
+        "ugliness" : 1,
+        "description" : "You are much smarter, and your skull bulges slightly.  Intelligence + 4",
+        "prereqs" : ["INT_UP_2"],
+        "changes_to" : ["INT_UP_4"],
+        "category" : ["ELFA"],
+        "passive_mods" : {
+            "int_mod" : 4
+        }
+    },{
+        "type" : "mutation",
+        "id" : "INT_UP_4",
+        "name" : "Insanely Smart",
+        "points" : 4,
+        "visibility" : 3,
+        "ugliness" : 3,
+        "description" : "Your skull bulges noticeably due to your impressive brain.  Intelligence + 7",
+        "prereqs" : ["INT_UP_3"],
+        "threshreq" : ["THRESH_CEPHALOPOD"],
+        "category" : ["CEPHALOPOD"],
+        "passive_mods" : {
+            "int_mod" : 7
+        }
+    },{
+        "type" : "mutation",
+        "id" : "INT_ALPHA",
+        "name" : "Prime Intelligence",
+        "points" : 6,
+        "description" : "You understand almost everything about which you think, with minimal effort.",
+        "valid" : false,
+        "prereqs" : ["INT_UP"],
+        "threshreq" : ["THRESH_ALPHA"],
+        "category" : ["ALPHA"],
+        "passive_mods" : {
+            "int_mod" : 1
+        }
+    },{
+        "type" : "mutation",
+        "id" : "INT_SLIME",
+        "name" : "Distributed Neurology",
+        "points" : 4,
+        "visibility" : 10,
+        "ugliness" : 10,
+        "description" : "Your brain has evolved beyond human imagination.  You'll show them the REAL meaning of 'gray goo'!",
+        "valid" : false,
+        "purifiable" : false,
+        "leads_to" : ["SLIMESPAWNER"],
+        "prereqs" : ["INT_UP"],
+        "prereqs2" : ["AMORPHOUS"],
+        "threshreq" : ["THRESH_SLIME"],
+        "category" : ["SLIME"],
+        "armor" : [ { "parts" : "ALL", "bash" : -3 } ]
+    },{
+        "type" : "mutation",
+        "id" : "PER_UP",
+        "name" : "Perceptive",
+        "points" : 1,
+        "description" : "Your senses are a little keener.  Perception + 1",
+        "changes_to" : ["PER_UP_2"],
+        "leads_to" : ["BIRD_EYE"],
+        "passive_mods" : {
+            "per_mod" : 1
+        }
+    },{
+        "type" : "mutation",
+        "id" : "PER_UP_2",
+        "name" : "Very Perceptive",
+        "points" : 2,
+        "description" : "Your senses are keener.  Perception + 2",
+        "prereqs" : ["PER_UP"],
+        "changes_to" : ["PER_UP_3", "PER_ALPHA"],
+        "category" : ["ALPHA", "CHIMERA"],
+        "passive_mods" : {
+            "per_mod" : 2
+        }
+    },{
+        "type" : "mutation",
+        "id" : "PER_UP_3",
+        "name" : "Extremely Perceptive",
+        "points" : 3,
+        "description" : "Your senses are much keener.  Perception + 4",
+        "prereqs" : ["PER_UP_2"],
+        "changes_to" : ["PER_UP_4"],
+        "category" : ["ELFA", "RAPTOR"],
+        "passive_mods" : {
+            "per_mod" : 4
+        }
+    },{
+        "type" : "mutation",
+        "id" : "PER_UP_4",
+        "name" : "Insanely Perceptive",
+        "points" : 4,
+        "description" : "You can sense things you never imagined.  Perception + 7",
+        "prereqs" : ["PER_UP_3"],
+        "threshreq" : ["THRESH_BIRD"],
+        "category" : ["BIRD"],
+        "passive_mods" : {
+            "per_mod" : 7
+        }
+    },{
+        "type" : "mutation",
+        "id" : "PER_ALPHA",
+        "name" : "Prime Perception",
+        "points" : 6,
+        "description" : "Your senses are keenly honed.",
+        "valid" : false,
+        "prereqs" : ["PER_UP_2"],
+        "threshreq" : ["THRESH_ALPHA"],
+        "category" : ["ALPHA"],
+        "passive_mods" : {
+            "per_mod" : 2
+        }
+    },{
+        "type" : "mutation",
+        "id" : "PER_SLIME",
+        "name" : "Sensory Disintegration",
+        "points" : -7,
+        "visibility" : 10,
+        "ugliness" : 10,
+        "description" : "Your sense organs are all over the place: eyes extending and retracting, 'ears' of various shapes migrating about, and taste & smell are uncontrollable.  The world is a horrible mixup.  Ugh!",
+        "valid" : false,
+        "purifiable" : false,
+        "changes_to" : ["PER_SLIME_OK"],
+        "prereqs" : ["PER_UP"],
+        "prereqs2" : ["AMORPHOUS"],
+        "threshreq" : ["THRESH_SLIME"],
+        "category" : ["SLIME"],
+        "passive_mods" : {
+            "per_mod" : -8
+        }
+    },{
+        "type" : "mutation",
+        "id" : "PER_SLIME_OK",
+        "name" : "Distributed Senses",
+        "points" : 7,
+        "visibility" : 10,
+        "ugliness" : 10,
+        "description" : "You can now extend and reabsorb sensory organs at will, and can therefore ignore most shocks that would overwhelm lesser beings.",
+        "valid" : false,
+        "purifiable" : false,
+        "leads_to" : ["SLIMESPAWNER"],
+        "prereqs" : ["PER_SLIME"],
+        "prereqs2" : ["AMORPHOUS"],
+        "threshreq" : ["THRESH_SLIME"],
+        "category" : ["SLIME"],
+        "passive_mods" : {
+            "per_mod" : 5
+        }
+    },{
+        "type" : "mutation",
+        "id" : "SMALL",
+        "name" : "Little",
+        "points" : -2,
+        "visibility" : 5,
+        "mixed_effect" : true,
+        "description" : "You've noticeably shrunk in size.  You're able to move with increased litheness, but your smaller stature prevents you from carrying as much.",
+        "cancels" : ["LARGE", "LARGE_OK", "HUGE", "HUGE_OK"],
+        "changes_to": ["SMALL2"],
+        "category" : ["MOUSE"],
+        "hp_modifier" : -0.05
+    },{
+        "type" : "mutation",
+        "id" : "SMALL2",
+        "name" : "Tiny",
+        "points" : -4,
+        "visibility" : 8,
+        "mixed_effect" : true,
+        "description" : "You're only half as tall as you used to be!  The weight of things you once found easy to carry is now unbearable, clothes are now twice as encumbering for you unless you refit them (since you're half their size), and your hit points are heavily reduced.  However, your movement is silent, and your dodge skill is a little higher.",
+        "prereqs" : ["SMALL"],
+        "cancels" : ["LARGE", "LARGE_OK", "HUGE", "HUGE_OK"],
+        "changes_to": ["SMALL_OK"],
+        "category" : ["MOUSE"],
+        "hp_modifier" : -0.3
+    },{
+        "type" : "mutation",
+        "id" : "SMALL_OK",
+        "name" : "Unassuming",
+        "points" : 3,
+        "mixed_effect" : true,
+        "description" : "You've mastered your tiny form!  Item encumbrance and carry weight penalties are reduced, and you've learned to use your increased nimbleness to offset your reduced capacity to absorb damage.",
+        "prereqs" : ["SMALL2"],
+        "cancels" : ["LARGE", "LARGE_OK", "HUGE", "HUGE_OK"],
+        "valid" : false,
+        "purifiable" : false,
+        "threshreq" : ["THRESH_MOUSE"],
+        "category" : ["MOUSE"],
+        "hp_modifier" : -0.25
+    },{
+        "type" : "mutation",
+        "id" : "CRAFTY",
+        "name" : "Crafty",
+        "points" : 4,
+        "description" : "By making the most of your small stature, you can avoid the notice of all but the most perceptive creatures, and your speed is greatly increased.",
+        "valid" : false,
+        "purifiable" : false,
+        "prereqs" : ["SMALL_OK"],
+        "threshreq" : ["THRESH_MOUSE"],
+        "category" : ["MOUSE"],
+        "stealth_modifier" : 40
+    },{
+        "type" : "mutation",
+        "id" : "MUT_JUNKIE",
+        "name" : "Metallassomaiphile",
+        "//" : "name courtesy of wiktionary's Greek for 'mutate'.  Greek-speakers, feel free to correct the term",
+        "points" : -1,
+        "description" : "Just thinking of mutagen (such a lovely word!  'Mutagen'.  Perfect!) makes you thirsty.  And you so love your new parts.  You simply must have more mutagen!",
+        "threshreq" : ["THRESH_MEDICAL", "THRESH_CHIMERA"],
+        "category" : ["MEDICAL", "CHIMERA"]
+    },{
+        "type" : "mutation",
+        "id" : "HEADBUMPS",
+        "name" : "Head Bumps",
+        "points" : 0,
+        "visibility" : 3,
+        "ugliness" : 3,
+        "description" : "You have a pair of bumps on your skull.",
+        "changes_to" : ["HORNS", "ANTENNAE"]
+    },{
+        "type" : "mutation",
+        "id" : "SLIT_NOSTRILS",
+        "name" : "Slit Nostrils",
+        "points" : -2,
+        "visibility" : 7,
+        "ugliness" : 4,
+        "description" : "You have a flattened nose and thin slits for nostrils, giving you a lizard-like appearance.  This makes breathing slightly difficult and increases mouth encumbrance by 10.",
+        "encumbrance_always" : [["MOUTH", 10]],
+        "category" : ["LIZARD", "CEPHALOPOD", "RAPTOR"]
+    },{
+        "type" : "mutation",
+        "id" : "FORKED_TONGUE",
+        "name" : "Forked Tongue",
+        "points" : 0,
+        "visibility" : 1,
+        "ugliness" : 3,
+        "description" : "Your tongue is forked, like that of a reptile.  This has no effect.",
+        "category" : ["LIZARD", "RAPTOR"]
+    },{
+        "type" : "mutation",
+        "id" : "EYEBULGE",
+        "name" : "Bulging Eyes",
+        "points" : 0,
+        "visibility" : 8,
+        "ugliness" : 4,
+        "description" : "Your eyes bulge out several inches from your skull.  This does not affect your vision in any way.",
+        "leads_to" : ["MEMBRANE"],
+        "changes_to" : ["COMPOUND_EYES"]
+    },{
+        "type" : "mutation",
+        "id" : "MOUTH_FLAPS",
+        "name" : "Mouth Flaps",
+        "points" : -1,
+        "visibility" : 7,
+        "ugliness" : 6,
+        "description" : "Skin tabs and odd flaps of skin surround your mouth.  They don't affect your eating, but are unpleasant to look at.",
+        "category" : ["CHIMERA"],
+        "leads_to" : ["MOUTH_TENTACLES", "MANDIBLES"]
+    },{
+        "type" : "mutation",
+        "id" : "WINGS_STUB",
+        "name" : "Wing Stubs",
+        "points" : 0,
+        "visibility" : 2,
+        "ugliness" : 2,
+        "description" : "You have a pair of stubby little wings projecting from your shoulderblades.  They can be wiggled at will, but are useless.",
+        "changes_to" : ["WINGS_BIRD", "WINGS_BAT", "WINGS_INSECT", "WINGS_BUTTERFLY"]
+    },{
+        "type" : "mutation",
+        "id" : "WINGS_BAT",
+        "name" : "Bat Wings",
+        "points" : -1,
+        "visibility" : 9,
+        "ugliness" : 4,
+        "description" : "You have a pair of large, leathery wings.  You can move them a little, but they are useless, and in fact put you off balance, reducing your ability to dodge slightly.",
+        "types" : ["WINGS"],
+        "prereqs" : ["WINGS_STUB"]
+    },{
+        "type" : "mutation",
+        "id" : "WINGS_BUTTERFLY",
+        "name" : "Butterfly Wings",
+        "points" : -1,
+        "visibility" : 10,
+        "ugliness" : -2,
+        "description" : "You have a very large and very beautiful pair of brightly-colored wings.  They can't lift you, and they make balancing tricky, but they certainly catch air and attention!",
+        "valid" : false,
+        "purifiable" : false,
+        "encumbrance_always" : [[ "TORSO", 10 ]],
+        "types" : ["WINGS"],
+        "prereqs" : ["WINGS_STUB"],
+        "threshreq" : ["THRESH_INSECT"],
+        "category" : ["INSECT"],
+        "restricts_gear" : [ "TORSO" ],
+        "social_modifiers" : {
+            "lie" : 15,
+            "persuade" : 5,
+            "intimidate" : -20
+        }
+    },{
+        "type" : "mutation",
+        "id" : "PALE",
+        "name" : "Pale Skin",
+        "points" : 0,
+        "visibility" : 3,
+        "ugliness" : 1,
+        "description" : "Your skin is rather pale.",
+        "changes_to" : ["ALBINO"],
+        "leads_to" : ["TROGLO"],
+        "category" : ["LUPINE"]
+    },{
+        "type" : "mutation",
+        "id" : "SPOTS",
+        "name" : "Spots",
+        "points" : 0,
+        "visibility" : 6,
+        "ugliness" : 2,
+        "description" : "Your skin is covered in a pattern of red spots.",
+        "changes_to" : ["SORES"]
+    },{
+        "type" : "mutation",
+        "id" : "SMELLY2",
+        "name" : "Smelly",
+        "points" : -2,
+        "visibility" : 4,
+        "ugliness" : 5,
+        "description" : "You smell awful.  Monsters that track scent will find you very easily, and humans will react poorly.",
+        "prereqs" : ["SMELLY"],
+        "leads_to" : ["PHEROMONE_INSECT", "PHEROMONE_MAMMAL"],
+        "category" : ["FISH", "BEAST", "SLIME", "CHIMERA", "URSINE"]
+    },{
+        "type" : "mutation",
+        "id" : "DEFORMED",
+        "name" : "Deformed",
+        "points" : -2,
+        "visibility" : 4,
+        "ugliness" : 4,
+        "description" : "You're minorly deformed.  Some people will react badly to your appearance.",
+        "cancels" : ["PRETTY", "BEAUTIFUL", "BEAUTIFUL2", "BEAUTIFUL3"],
+        "prereqs" : ["UGLY"],
+        "changes_to" : ["DEFORMED2"],
+        "category" : ["FISH", "CATTLE", "INSECT", "CEPHALOPOD", "FELINE", "LUPINE"]
+    },{
+        "type" : "mutation",
+        "id" : "DEFORMED2",
+        "name" : "Badly Deformed",
+        "points" : -3,
+        "visibility" : 7,
+        "ugliness" : 7,
+        "description" : "You're hideously deformed.  Some people will have a strong negative reaction to your appearance.",
+        "cancels" : ["PRETTY", "BEAUTIFUL", "BEAUTIFUL2", "BEAUTIFUL3"],
+        "prereqs" : ["DEFORMED"],
+        "changes_to" : ["DEFORMED3"],
+        "category" : ["BEAST", "URSINE", "PLANT"]
+    },{
+        "type" : "mutation",
+        "id" : "DEFORMED3",
+        "name" : "Grotesque",
+        "points" : -4,
+        "visibility" : 10,
+        "ugliness" : 10,
+        "description" : "Your visage is disgusting and liable to induce vomiting.  People will not want to interact with you unless they have a very good reason to.",
+        "cancels" : ["PRETTY", "BEAUTIFUL", "BEAUTIFUL2", "BEAUTIFUL3"],
+        "prereqs" : ["DEFORMED2"],
+        "category" : ["SLIME", "RAT", "CHIMERA"]
+    },{
+        "type" : "mutation",
+        "id" : "BEAUTIFUL",
+        "name" : "Beautiful",
+        "points" : 2,
+        "visibility" : -4,
+        "ugliness" : -4,
+        "description" : "You're a real head-turner.  Some people will react well to your appearance, and most people have an easier time trusting you.",
+        "cancels" : ["UGLY", "DEFORMED", "DEFORMED2", "DEFORMED3"],
+        "prereqs" : ["PRETTY"],
+        "changes_to" : ["BEAUTIFUL2"]
+    },{
+        "type" : "mutation",
+        "id" : "BEAUTIFUL2",
+        "name" : "Very Beautiful",
+        "points" : 3,
+        "visibility" : -7,
+        "ugliness" : -7,
+        "description" : "You are a vision of beauty.  Some people will react very well to your looks, and most people will trust you immediately.",
+        "cancels" : ["UGLY", "DEFORMED", "DEFORMED2", "DEFORMED3"],
+        "prereqs" : ["BEAUTIFUL"],
+        "changes_to" : ["BEAUTIFUL3"]
+    },{
+        "type" : "mutation",
+        "id" : "BEAUTIFUL3",
+        "name" : "Glorious",
+        "points" : 4,
+        "visibility" : -10,
+        "ugliness" : -10,
+        "description" : "You are incredibly beautiful.  People cannot help themselves due to your charms, and will do whatever they can to please you.",
+        "cancels" : ["UGLY", "DEFORMED", "DEFORMED2", "DEFORMED3"],
+        "prereqs" : ["BEAUTIFUL2"],
+        "category": ["ELFA"]
+    },{
+        "type" : "mutation",
+        "id" : "SNOUT",
+        "name" : "Snout",
+        "points" : -1,
+        "visibility" : 4,
+        "ugliness" : 3,
+        "description" : "Your face and jaw have begun...changing.  Masks and such fit OK, but you're noticeably mutated.",
+        "changes_to" : ["BEAK", "BEAK_HUM", "BEAK_PECK", "PROBOSCIS", "MINOTAUR", "MUZZLE", "MUZZLE_BEAR", "MUZZLE_LONG", "MUZZLE_RAT"],
+        "category" : ["FELINE"]
+    },{
+        "type" : "mutation",
+        "id" : "MINOTAUR",
+        "name" : "Bovine Snout",
+        "points" : -4,
+        "visibility" : 5,
+        "ugliness" : 6,
+        "mixed_effect" : true,
+        "description" : "Your face resembles that of a bull, with a significant snout.  It looks fearsome but prevents wearing mouthgear.",
+        "types" : ["MUZZLE"],
+        "prereqs" : ["SNOUT"],
+        "category" : ["CATTLE"],
+        "restricts_gear" : [ "MOUTH" ],
+        "social_modifiers" : {
+            "intimidate" : 15
+        }
+    },{
+        "type" : "mutation",
+        "id" : "MUZZLE",
+        "name" : "Lupine Muzzle",
+        "points" : -2,
+        "visibility" : 5,
+        "ugliness" : 4,
+        "mixed_effect" : true,
+        "description" : "Your jaw and nose have extended into a wolfish muzzle.  It lends itself to biting in combat and looks impressive, but prevents wearing mouthgear.",
+        "types" : ["MUZZLE"],
+        "prereqs" : ["SNOUT"],
+        "category" : ["BEAST", "LUPINE"],
+        "restricts_gear" : [ "MOUTH" ],
+        "social_modifiers" : {
+            "intimidate" : 6
+        },
+        "attacks" : {
+            "attack_text_u" : "You nip at %s",
+            "attack_text_npc" : "%1$s nips and harries %2$s",
+            "blocker_mutations" : [ "FANGS" ],
+            "body_part" : "MOUTH",
+            "chance" : 18,
+            "base_damage" : { "damage_type" : "cut", "amount" : 4 }
+        }
+    },{
+        "type" : "mutation",
+        "id" : "MUZZLE_BEAR",
+        "name" : "Ursine Muzzle",
+        "points" : -2,
+        "visibility" : 5,
+        "ugliness" : 4,
+        "mixed_effect" : true,
+        "description" : "Your jaw and nose have extended into a bearish muzzle.  You could bite with it, and it looks impressive, but it prevents wearing mouthgear.",
+        "types" : ["MUZZLE"],
+        "prereqs" : ["SNOUT"],
+        "category" : ["URSINE"],
+        "restricts_gear" : [ "MOUTH" ],
+        "attacks" : {
+            "attack_text_u" : "You bite %s",
+            "attack_text_npc" : "%1$s bites %2$s",
+            "blocker_mutations" : [ "FANGS" ],
+            "body_part" : "MOUTH",
+            "chance" : 20,
+            "base_damage" : { "damage_type" : "cut", "amount" : 5 }
+        }
+    },{
+        "type" : "mutation",
+        "id" : "MUZZLE_RAT",
+        "name" : "Rodent Muzzle",
+        "points" : -2,
+        "visibility" : 6,
+        "ugliness" : 4,
+        "description" : "Your face and jaw have extended, giving you an alert and attentive appearance.",
+        "types" : ["MUZZLE"],
+        "prereqs" : ["SNOUT"],
+        "category" : ["RAT"],
+        "restricts_gear" : [ "MOUTH" ]
+    },{
+        "type" : "mutation",
+        "id" : "MUZZLE_LONG",
+        "name" : "Reptilian Muzzle",
+        "points" : -3,
+        "visibility" : 8,
+        "ugliness" : 8,
+        "mixed_effect" : true,
+        "description" : "Your face and jaws are a shorter version of those found on alligators.  They look NASTY--as do the bite wounds they can inflict--but prevent wearing mouthgear.",
+        "types" : ["MUZZLE"],
+        "prereqs" : ["SNOUT"],
+        "category" : ["LIZARD"],
+        "restricts_gear" : [ "MOUTH" ],
+        "social_modifiers" : {
+            "intimidate" : 20
+        },
+        "attacks" : {
+            "attack_text_u" : "You bite a chunk out of %s",
+            "attack_text_npc" : "%1$s bites a chunk out of %2$s",
+            "blocker_mutations" : [ "FANGS" ],
+            "body_part" : "MOUTH",
+            "chance" : 18,
+            "base_damage" : { "damage_type" : "stab", "amount" : 18 }
+        }
+    },{
+        "type" : "mutation",
+        "id" : "PROBOSCIS",
+        "name" : "Proboscis",
+        "points" : -4,
+        "visibility" : 5,
+        "ugliness" : 7,
+        "description" : "You've gotten rid of that terribly imprecise mouth and now imbibe your food like a proper person.  Chewing was tiresome anyway.",
+        "valid" : false,
+        "purifiable" : false,
+        "types" : ["TEETH", "MUZZLE"],
+        "cancels" : ["MOUTH_TENTACLES"],
+        "prereqs" : ["EYEBULGE", "COMPOUND_EYES"],
+        "threshreq" : ["THRESH_INSECT"],
+        "category" : ["INSECT"],
+        "active" : true,
+        "restricts_gear" : [ "MOUTH" ]
+    },{
+        "type" : "mutation",
+        "id" : "HOLLOW_BONES",
+        "name" : "Hollow Bones",
+        "points" : 1,
+        "mixed_effect" : true,
+        "description" : "You have Avian Bone Syndrome--your bones are nearly hollow.  Your body is very light as a result, enabling you to move and attack 20% faster, but also frail; you can carry 40% less, and bashing attacks injure you more.",
+        "prereqs" : ["LIGHT_BONES"],
+        "category" : ["BIRD", "SLIME", "ELFA"]
+    },{
+        "type" : "mutation",
+        "id" : "NAUSEA",
+        "name" : "Nausea",
+        "points" : -2,
+        "description" : "You feel nauseous almost constantly, and are more liable to throw up from food poisoning, alcohol, etc.  You can, if desired, think yourself into vomiting, too.",
+        "prereqs" : ["WEAKSTOMACH"],
+        "changes_to" : ["VOMITOUS", "EATPOISON"],
+        "category" : ["ALPHA"],
+        "active" : true
+    },{
+        "type" : "mutation",
+        "id" : "VOMITOUS",
+        "name" : "Vomitous",
+        "points" : -3,
+        "description" : "You have a major digestive disorder.  Though it causes you to vomit frequently, you have found that you can trigger your vomit reflex on demand, too.",
+        "prereqs" : ["NAUSEA"],
+        "changes_to" : ["EATPOISON"],
+        "category" : ["SLIME", "RAT", "MEDICAL", "ELFA"],
+        "active" : true
+    },{
+        "type" : "mutation",
+        "id" : "HUNGER",
+        "name" : "Fast Metabolism",
+        "points" : -2,
+        "description" : "You require more food than most people, but recover stamina slightly faster.",
+        "starting_trait" : true,
+        "types" : ["METABOLISM"],
+        "changes_to" :["HUNGER2", "MET_RAT"],
+        "category" : ["RAT", "ALPHA", "MEDICAL", "ELFA", "BEAST", "SLIME", "RAPTOR", "CHIMERA", "MOUSE"],
+        "metabolism_modifier": 0.5,
+        "stamina_regen_modifier": 0.1
+    },{
+        "type" : "mutation",
+        "id" : "MET_RAT",
+        "name" : "Rapid Metabolism",
+        "points" : -2,
+        "valid" : false,
+        "description" : "You require more resources than most, but heal more rapidly as well.  Provides weak regeneration even when not asleep.",
+        "types" : ["HEALING"],
+        "cancels" : ["LIGHTEATER", "COLDBLOOD", "COLDBLOOD2", "COLDBLOOD3", "COLDBLOOD4", "WAKEFUL", "WAKEFUL2", "WAKEFUL3"],
+        "prereqs" : ["HUNGER"],
+        "prereqs2" : ["SLEEPY"],
+        "category" : ["RAT", "MOUSE"],
+        "healing_awake" : 0.2,
+        "healing_resting" : 0.5,
+        "fatigue_modifier": 0.5,
+        "fatigue_regen_modifier": 0.333,
+        "metabolism_modifier": 0.333
+    },{
+        "type" : "mutation",
+        "id" : "HUNGER2",
+        "name" : "Very Fast Metabolism",
+        "points" : -2,
+        "description" : "You need about twice as much food as the average human to maintain your expanded cardiovascular and respiratory systems.  On a plus side, it doesn't take you much time to recover from any strenuous activity.",
+        "prereqs" : ["HUNGER"],
+        "changes_to" :["HUNGER3"],
+        "types" : ["METABOLISM"],
+        "category" : ["BEAST", "SLIME", "RAPTOR"],
+        "metabolism_modifier": 1.0,
+        "stamina_regen_modifier": 0.3
+    },{
+        "type" : "mutation",
+        "id" : "HUNGER3",
+        "name" : "Extreme Metabolism",
+        "points" : -2,
+        "description" : "You consume three times as much food as the average human to maintain your truly superhuman endurance.",
+        "prereqs" : ["HUNGER2"],
+        "leads_to" : ["EATHEALTH"],
+        "types" : ["METABOLISM"],
+        "category" : ["CHIMERA"],
+        "metabolism_modifier": 2.0,
+        "stamina_regen_modifier": 0.5
+    },{
+        "type" : "mutation",
+        "id" : "THIRST",
+        "name" : "High Thirst",
+        "points" : -2,
+        "description" : "Your body dries out easily; you need to drink more water.",
+        "starting_trait" : true,
+        "changes_to" : ["THIRST2"],
+        "cancels" : ["NO_THIRST" ],
+        "category" : ["SLIME", "CEPHALOPOD", "CHIMERA", "ELFA"],
+        "thirst_modifier": 0.5
+    },{
+        "type" : "mutation",
+        "id" : "THIRST2",
+        "name" : "Very Thirsty",
+        "points" : -3,
+        "description" : "Ugh, out of water already?  You need about twice the fluids of an average human.",
+        "prereqs" : ["THIRST"],
+        "changes_to" :["THIRST3"],
+        "cancels" : ["NO_THIRST" ],
+        "category" : ["FISH", "SLIME", "CEPHALOPOD"],
+        "thirst_modifier": 1.0
+    },{
+        "type" : "mutation",
+        "id" : "THIRST3",
+        "name" : "Extremely Thirsty",
+        "points" : -5,
+        "description" : "You dry out seriously quickly, requiring three times as much liquid to stay hydrated.",
+        "cancels" : ["NO_THIRST" ],
+        "prereqs" : ["THIRST2"],
+        "thirst_modifier": 2.0
+    },{
+        "type" : "mutation",
+        "id" : "NO_THIRST",
+        "name" : "Metabolic Rehydration",
+        "points" : 6,
+        "description" : "Your body gets everything it needs from the food that you eat!  You no longer gain hydration from fluids - instead, your thirst will be equal to, and change with, your hunger.",
+        "threshreq" : ["THRESH_MOUSE"],
+        "category" : ["MOUSE"],
+        "cancels" : ["THIRST", "THIRST2", "THIRST3"],
+        "purifiable": false
+    },{
+        "type" : "mutation",
+        "id" : "HEAVYSLEEPER2",
+        "name" : "Very Heavy Sleeper",
+        "points" : -2,
+        "description" : "You could probably sleep through a firefight.",
+        "valid" : false,
+        "prereqs" : ["HEAVYSLEEPER"],
+        "category" : ["BEAST", "LUPINE"]
+    },{
+        "type" : "mutation",
+        "id" : "SLEEPY2",
+        "name" : "Very Sleepy",
+        "points" : -3,
+        "description" : "You find yourself needing to sleep quite often.  You'll spend about half of your time in or around bed.",
+        "prereqs" : ["SLEEPY"],
+        "types" : ["SLEEP"],
+        "category" : ["FELINE"],
+        "fatigue_modifier": 1.0
+    },{
+        "type" : "mutation",
+        "id" : "ROT1",
+        "name" : "Weakening",
+        "points" : -2,
+        "bodytemp_modifiers" : [-250, -250],
+        "description" : "You feel as though you are slowly weakening and your body heals slower.",
+        "types" : ["HEALING"],
+        "changes_to" : ["ROT2"],
+        "category" : ["ELFA"],
+        "healing_awake" : -0.002,
+        "healing_resting" : -0.25
+    },{
+        "type" : "mutation",
+        "id" : "ROT2",
+        "name" : "Deterioration",
+        "points" : -8,
+        "bodytemp_modifiers" : [-750, -750],
+        "description" : "Your body is very slowly wasting away.",
+        "types" : ["HEALING"],
+        "prereqs" : ["ROT1"],
+        "changes_to" : ["ROT3"],
+        "category" : ["CHIMERA"],
+        "healing_awake" : -0.02
+    },{
+        "type" : "mutation",
+        "id" : "ROT3",
+        "name" : "Disintegration",
+        "points" : -10,
+        "bodytemp_modifiers" : [-1500, -1500],
+        "description" : "Your body is slowly wasting away!",
+        "types" : ["HEALING"],
+        "prereqs" : ["ROT2"],
+        "category": ["ALPHA"],
+        "healing_awake" : -0.08
+    },{
+        "type" : "mutation",
+        "id" : "SUNBURN",
+        "name" : "Solar Sensitivity",
+        "points" : -3,
+        "description" : "Your skin simply cannot handle ultraviolet radiation, such as sunlight.  It will seriously burn you.",
+        "prereqs" : ["ALBINO"],
+        "prereqs2" : ["TROGLO2", "TROGLO3"],
+        "category" : ["TROGLOBITE"]
+    },{
+        "type" : "mutation",
+        "id" : "SORES",
+        "name" : "Sores",
+        "points" : -2,
+        "visibility" : 5,
+        "ugliness" : 6,
+        "description" : "Your extremities are covered in painful sores.  The pain is worse when they are covered in clothing.",
+        "prereqs" : ["SPOTS"],
+        "category" : ["SLIME"]
+    },{
+        "type" : "mutation",
+        "id" : "TROGLO",
+        "name" : "Light Sensitive",
+        "points" : -2,
+        "description" : "Sunlight makes you uncomfortable.  If you are outdoors and the weather is Sunny, you suffer -1 to all stats.",
+        "cancels" : ["SUNLIGHT_DEPENDENT"],
+        "changes_to" : ["TROGLO2"],
+        "category" : ["LIZARD", "BEAST", "INSECT", "SLIME", "SPIDER"]
+    },{
+        "type" : "mutation",
+        "id" : "TROGLO2",
+        "name" : "Very Light Sensitive",
+        "points" : -3,
+        "description" : "Sunlight makes you very uncomfortable.  If you are outdoors during the day, you suffer -1 to all stats; -2 if the weather is Sunny.",
+        "cancels" : ["SUNLIGHT_DEPENDENT"],
+        "prereqs" : ["TROGLO"],
+        "changes_to" : ["TROGLO3"],
+        "category" : ["RAT"]
+    },{
+        "type" : "mutation",
+        "id" : "TROGLO3",
+        "name" : "Troglobite",
+        "points" : -5,
+        "description" : "Sunlight makes you extremely uncomfortable, resulting in large penalties to all stats.",
+        "cancels" : ["SUNLIGHT_DEPENDENT"],
+        "prereqs" : ["TROGLO2"],
+        "category" : ["TROGLOBITE"]
+    },{
+        "type" : "mutation",
+        "id" : "WEBBED",
+        "name" : "Webbed Hands",
+        "points" : -2,
+        "visibility" : 3,
+        "ugliness" : 2,
+        "cancels" : ["ARM_TENTACLES", "ARM_TENTACLES_4", "ARM_TENTACLES_8"],
+        "description" : "Your hands and feet are heavily webbed, reducing your Dexterity by 1 and causing problems with gloves.  However, you can swim much faster.  Slightly decreases wet penalties.",
+        "category" : ["LIZARD", "FISH", "SLIME"],
+        "wet_protection" : [
+            { "part" : "HAND_L", "good" : 3 },
+            { "part" : "HAND_R", "good" : 3 }
+        ],
+        "encumbrance_covered" : [
+            [ "HAND_L", 50 ],
+            [ "HAND_R", 50 ]
+        ]
+    },{
+        "type" : "mutation",
+        "id" : "PAWS",
+        "name" : "Paws",
+        "points" : -3,
+        "visibility" : 3,
+        "ugliness" : 2,
+        "mixed_effect" : true,
+        "description" : "Your hands have fused into quasi-paws.  Fine manipulation is a challenge: permanent hand encumbrance of 10, difficulty with delicate craftwork, and your gloves don't fit.  But they handle water better.",
+        "encumbrance_always" : [
+            [ "HAND_L", 10 ],
+            [ "HAND_R", 10 ]
+        ],
+        "restricts_gear" : [ "HAND_L", "HAND_R" ],
+        "types" : ["HANDS"],
+        "prereqs" : ["CLAWS", "CLAWS_RETRACT", "CLAWS_RAT"],
+        "cancels" : ["TALONS"],
+        "changes_to" : ["PAWS_LARGE"],
+        "category" : ["LUPINE", "RAT", "FELINE"]
+    },{
+        "type" : "mutation",
+        "id" : "PAWS_LARGE",
+        "name" : "Broad Paws",
+        "points" : -4,
+        "visibility" : 4,
+        "ugliness" : 3,
+        "mixed_effect" : true,
+        "description" : "Your paws are much larger now.  Manual dexterity is difficult: permanent hand encumbrance of 20, serious problems crafting, and no gloves.  But you can swim more effectively.",
+        "encumbrance_always" : [
+            [ "HAND_L", 20 ],
+            [ "HAND_R", 20 ]
+        ],
+        "restricts_gear" : [ "HAND_L", "HAND_R" ],
+        "types" : ["HANDS"],
+        "prereqs" : ["PAWS"],
+        "cancels" : ["TALONS"],
+        "category" : ["BEAST", "URSINE"]
+    },{
+        "type" : "mutation",
+        "id" : "BEAK",
+        "name" : "Beak",
+        "points" : -3,
+        "visibility" : 8,
+        "ugliness" : 4,
+        "mixed_effect" : true,
+        "description" : "You have a beak for a mouth.  You can occasionally use it to peck at your enemies, but it is impossible for you to wear mouth gear.  Slightly reduces wet effects.",
+        "types" : ["TEETH", "MUZZLE"],
+        "changes_to" : ["BEAK_HUM", "BEAK_PECK"],
+        "category" : ["BIRD", "CEPHALOPOD"],
+        "wet_protection" : [
+            { "part" : "MOUTH", "ignored" : 1 }
+        ],
+        "restricts_gear" : [ "MOUTH" ],
+        "destroys_gear" : true,
+        "attacks" : {
+            "attack_text_u" : "You peck %s",
+            "attack_text_npc" : "%1$s pecks %2$s",
+            "body_part" : "MOUTH",
+            "chance" : 15,
+            "base_damage" : { "damage_type" : "stab", "amount" : 15 }
+        }
+    },{
+        "type" : "mutation",
+        "id" : "BEAK_PECK",
+        "name" : "Woodpecker Beak",
+        "points" : -2,
+        "visibility" : 10,
+        "ugliness" : 5,
+        "description" : "Pecking at prey is part of your daily routine now.  Slightly reduces wet effects.",
+        "valid" : false,
+        "purifiable" : false,
+        "types" : ["TEETH", "MUZZLE"],
+        "cancels" : ["MOUTH_TENTACLES"],
+        "prereqs" : ["BEAK"],
+        "threshreq" : ["THRESH_BIRD"],
+        "category" : ["BIRD"],
+        "wet_protection" : [
+            { "part" : "MOUTH", "ignored" : 2 }
+        ],
+        "restricts_gear" : [ "MOUTH" ],
+        "destroys_gear" : true,
+        "attacks": [
+            {
+                "attack_text_u" : "You jackhammer into %s with your beak",
+                "attack_text_npc" : "%1$s jackhammer into %2$s with their beak",
+                "body_part" : "MOUTH",
+                "chance" : 15,
+                "hardcoded_effect" : true
+            }
+        ]
+    },{
+        "type" : "mutation",
+        "id" : "BEAK_HUM",
+        "name" : "Hummingbird Beak",
+        "points" : -2,
+        "visibility" : 10,
+        "ugliness" : 5,
+        "description" : "Though your beak's not suitable for pecking, those flowers out there are a good source of energy.  Examine them to feed.",
+        "valid" : false,
+        "purifiable" : false,
+        "types" : ["TEETH", "MUZZLE"],
+        "cancels" : ["MOUTH_TENTACLES"],
+        "prereqs" : ["BEAK"],
+        "threshreq" : ["THRESH_BIRD"],
+        "category" : ["BIRD"],
+        "wet_protection" : [
+            { "part" : "MOUTH", "ignored" : 2 }
+        ],
+        "active" : true,
+        "restricts_gear" : [ "MOUTH" ],
+        "destroys_gear" : true
+    },{
+        "type" : "mutation",
+        "id" : "UNSTABLE",
+        "name" : "Genetically Unstable",
+        "points" : -2,
+        "mixed_effect" : true,
+        "description" : "Your DNA has been damaged in a way that causes you to continually develop more mutations.",
+        "changes_to" : ["CHAOTIC"],
+        "category" : ["SLIME", "MEDICAL", "CHIMERA"]
+    },{
+        "type" : "mutation",
+        "id" : "CHAOTIC",
+        "name" : "Genetic Chaos",
+        "points" : -4,
+        "purifiable" : false,
+        "description" : "Your body alters itself rapidly, and without your intervention or conscious control.",
+        "prereqs" : ["UNSTABLE", "MUT_JUNKIE"],
+        "category" : ["CHIMERA"]
+    },{
+        "type" : "mutation",
+        "id" : "RADIOACTIVE1",
+        "name" : "Minor Radioactivity",
+        "points" : -2,
+        "bodytemp_modifiers" : [250, 250],
+        "description" : "Your body has become radioactive!  You continuously emit low levels of radiation, which slowly contaminates the world around you.",
+        "changes_to" : ["RADIOACTIVE2"],
+        "category" : ["SLIME"]
+    },{
+        "type" : "mutation",
+        "id" : "RADIOACTIVE2",
+        "name" : "Radioactivity",
+        "points" : -4,
+        "bodytemp_modifiers" : [750, 750],
+        "description" : "Your body has become radioactive!  You continuously emit moderate levels of radiation, which contaminates the world around you.",
+        "prereqs" : ["RADIOACTIVE1"],
+        "changes_to" : ["RADIOACTIVE3"],
+        "category": ["ELFA"]
+    },{
+        "type" : "mutation",
+        "id" : "RADIOACTIVE3",
+        "name" : "Severe Radioactivity",
+        "points" : -6,
+        "bodytemp_modifiers" : [1500, 1500],
+        "description" : "Your body has become radioactive!  You continuously emit heavy levels of radiation, making your surroundings unlivable.",
+        "prereqs" : ["RADIOACTIVE2"]
+    },{
+        "type" : "mutation",
+        "id" : "SLIMY",
+        "name" : "Slimy",
+        "points" : 2,
+        "visibility" : 7,
+        "ugliness" : 6,
+        "description" : "Your body is coated with a fine slime.  Protects from long term effects of acid, though not short term ones.  Greatly increases wet benefits.",
+        "leads_to" : ["SLIME_HANDS"],
+        "changes_to" : ["VISCOUS"],
+        "category" : ["FISH", "SLIME", "TROGLOBITE", "CEPHALOPOD"],
+        "wet_protection" : [
+            { "part" : "HEAD", "neutral" : 3, "good" : 4 },
+            { "part" : "LEG_L", "neutral" : 7, "good" : 14 },
+            { "part" : "LEG_R", "neutral" : 7, "good" : 14 },
+            { "part" : "FOOT_L", "neutral" : 2, "good" : 4 },
+            { "part" : "FOOT_R", "neutral" : 2, "good" : 4 },
+            { "part" : "ARM_L", "neutral" : 7, "good" : 12 },
+            { "part" : "ARM_R", "neutral" : 7, "good" : 12 },
+            { "part" : "HAND_L", "neutral" : 2, "good" : 3 },
+            { "part" : "HAND_R", "neutral" : 2, "good" : 3 },
+            { "part" : "TORSO", "neutral" : 14, "good" : 26 }
+        ]
+    },{
+        "type" : "mutation",
+        "id" : "VISCOUS",
+        "name" : "Viscous",
+        "points" : 4,
+        "visibility" : 7,
+        "ugliness" : 8,
+        "description" : "Your body's slime output has become sticky and gel-like.  Protects from acid somewhat.  Greatly increases wet benefits.",
+        "leads_to" : ["AMORPHOUS"],
+        "prereqs" : ["SLIMY"],
+        "threshreq" : ["THRESH_SLIME"],
+        "category" : ["SLIME"],
+        "wet_protection" : [
+            { "part" : "HEAD", "neutral" : 4, "good" : 5 },
+            { "part" : "LEG_L", "neutral" : 8, "good" : 15 },
+            { "part" : "LEG_R", "neutral" : 8, "good" : 15 },
+            { "part" : "FOOT_L", "neutral" : 3, "good" : 5 },
+            { "part" : "FOOT_R", "neutral" : 3, "good" : 5 },
+            { "part" : "ARM_L", "neutral" : 8, "good" : 14 },
+            { "part" : "ARM_R", "neutral" : 8, "good" : 14 },
+            { "part" : "HAND_L", "neutral" : 3, "good" : 4 },
+            { "part" : "HAND_R", "neutral" : 3, "good" : 4 },
+            { "part" : "TORSO", "neutral" : 15, "good" : 27 }
+        ],
+        "armor" : [ { "parts" : "ALL", "acid" : 2 } ]
+    },{
+        "type" : "mutation",
+        "id" : "AMORPHOUS",
+        "name" : "Amorphous Body",
+        "points" : -2,
+        "visibility" : 10,
+        "ugliness" : 10,
+        "description" : "Your flesh is a pleasing gel-like consistency.  Your bodily functions seem to be moving around, and your leg-equivalents flow comfortably.",
+        "purifiable" : false,
+        "leads_to" : ["INT_SLIME", "PER_SLIME"],
+        "prereqs" : ["VISCOUS"],
+        "prereqs2" : ["BENDY2", "SLIME_HANDS"],
+        "threshreq" : ["THRESH_SLIME"],
+        "category" : ["SLIME"],
+        "armor" : [ { "parts" : "ALL", "bash" : 4 } ]
+    },{
+        "type" : "mutation",
+        "id" : "SLIMESPAWNER",
+        "name" : "Omnicellular",
+        "points" : 10,
+        "visibility" : 10,
+        "ugliness" : 10,
+        "description" : "Your body is more or less one consistent whole: a single, giant, omni-cell that alters itself as needed.",
+        "valid" : false,
+        "purifiable" : false,
+        "prereqs" : ["INT_SLIME"],
+        "prereqs2" : ["PER_SLIME_OK"],
+        "threshreq" : ["THRESH_SLIME"],
+        "category" : ["SLIME"],
+        "active"     :    true,
+        "cost"       :    40,
+        "hunger"     :    true,
+        "thirst"     :    true
+    },{
+        "type" : "mutation",
+        "id" : "HERBIVORE",
+        "name" : "Herbivore",
+        "points" : -3,
+        "description" : "Your body's ability to digest meat is severely hampered.  Eating meat has a good chance of making you vomit it back up; even if you manage to keep it down, its nutritional value is greatly reduced.",
+        "cancels" : ["CARNIVORE", "SAPROVORE", "ANTIFRUIT", "MEATARIAN"],
+        "leads_to" : ["RUMINANT"]
+    },{
+        "type" : "mutation",
+        "id" : "CARNIVORE",
+        "name" : "Carnivore",
+        "points" : -4,
+        "description" : "Your body's ability to digest fruits, vegetables and grains is severely hampered.  You cannot eat anything besides meat.",
+        "cancels" : ["VEGETARIAN", "HERBIVORE", "RUMINANT",  "GRAZER"],
+        "leads_to" : ["SAPROVORE"],
+        "category" : ["LIZARD", "BEAST", "SPIDER", "CHIMERA", "RAPTOR", "FELINE"],
+        "vitamin_rates": [ [ "vitC", -1200 ] ]
+    },{
+        "type" : "mutation",
+        "id" : "PONDEROUS1",
+        "name" : "Ponderous",
+        "points" : -3,
+        "description" : "Your muscles are generally slow to move.  You move 10% slower.",
+        "types" : ["RUNNING"],
+        "changes_to" : ["PONDEROUS2"],
+        "category" : ["URSINE"]
+    },{
+        "type" : "mutation",
+        "id" : "PONDEROUS2",
+        "name" : "Very Ponderous",
+        "points" : -5,
+        "description" : "Your muscles are quite slow to move.  You move 20% slower.",
+        "types" : ["RUNNING"],
+        "prereqs" : ["PONDEROUS1"],
+        "changes_to" : ["PONDEROUS3"],
+        "category" : ["CATTLE"]
+    },{
+        "type" : "mutation",
+        "id" : "PONDEROUS3",
+        "name" : "Extremely Ponderous",
+        "points" : -6,
+        "description" : "Your muscles are very slow to move.  You move 30% slower.",
+        "types" : ["RUNNING"],
+        "prereqs" : ["PONDEROUS2"],
+        "category" : ["PLANT"]
+    },{
+        "type" : "mutation",
+        "id" : "SUNLIGHT_DEPENDENT",
+        "name" : "Sunlight Dependent",
+        "points" : -5,
+        "description" : "You feel very sluggish when not in direct sunlight.  You suffer a 5% drop in speed when in shade, and a 10% drop in speed when in the dark.",
+        "cancels" : ["TROGLO", "TROGLO2", "TROGLO3"],
+        "category" : ["PLANT"]
+    },{
+        "type" : "mutation",
+        "id" : "VINES1",
+        "name" : "Vines",
+        "points" : -2,
+        "visibility" : 8,
+        "ugliness" : 5,
+        "description" : "You have developed several vines sprouting from your shoulder area.  They're bulky and get in the way.",
+        "types" : ["WINGS"],
+        "prereqs" : ["PLANTSKIN", "BARK"],
+        "changes_to" : ["VINES2"],
+        "category" : ["PLANT"],
+        "encumbrance_always" : [
+            [ "TORSO", 10 ]
+        ]
+    },{
+        "type" : "mutation",
+        "id" : "VINES2",
+        "name" : "Vine Limbs",
+        "points" : 2,
+        "visibility" : 8,
+        "ugliness" : 5,
+        "description" : "You've developed the ability to control your vines; they make good lashes.  You can even rappel down sheer drops using them, but disconnecting HURTS.",
+        "types" : ["WINGS"],
+        "prereqs" : ["PLANTSKIN", "BARK"],
+        "prereqs2" : ["VINES1"],
+        "changes_to" : ["VINES3"],
+        "category" : ["PLANT"],
+        "attacks": [
+            {
+                "attack_text_u" : "You lash %s with a vine",
+                "attack_text_npc" : "%1$s lashes %2$s with their vines",
+                "chance" : 1,
+                "hardcoded_effect" : true
+            }
+        ],
+        "encumbrance_always" : [
+            [ "TORSO", 10 ]
+        ]
+    },{
+        "type" : "mutation",
+        "id" : "VINES3",
+        "name" : "Vine Sprouter",
+        "points" : 5,
+        "visibility" : 10,
+        "ugliness" : 6,
+        "description" : "You have full control of your vines, and can grow new ones and detach old ones more or less at will.",
+        "types" : ["WINGS"],
+        "prereqs" : ["PLANTSKIN", "BARK"],
+        "prereqs2" : ["VINES2"],
+        "threshreq" : ["THRESH_PLANT"],
+        "category" : ["PLANT"],
+        "active"     :    true,
+        "cost"       :    10,
+        "hunger"     :    true,
+        "thirst"     :    true,
+        "spawn_item" : { "type": "vine_30", "message": "You detach a vine from your body." },
+        "attacks": [
+            {
+                "attack_text_u" : "You lash %s with a vine",
+                "attack_text_npc" : "%1$s lashes %2$s with their vines",
+                "chance" : 1,
+                "hardcoded_effect" : true
+            }
+        ]
+    },{
+        "type" : "mutation",
+        "id" : "ROOTS1",
+        "name" : "Toe Roots",
+        "points" : -2,
+        "visibility" : 1,
+        "ugliness" : 5,
+        "description" : "Your toes have grown wriggly, and you can't imagine why you wear that stuff on your feet.  Take it off.  It's in the way.",
+        "prereqs" : ["PLANTSKIN"],
+        "threshreq" : ["THRESH_PLANT"],
+        "changes_to" : ["ROOTS2"],
+        "cancels" : ["LEG_TENTACLES", "HOOVES"],
+        "category" : ["PLANT"],
+        "encumbrance_covered" : [
+            [ "FOOT_L", 10 ],
+            [ "FOOT_R", 10 ]
+        ]
+    },{
+        "type" : "mutation",
+        "id" : "ROOTS2",
+        "name" : "Roots",
+        "points" : 2,
+        "visibility" : 4,
+        "ugliness" : 5,
+        "//~" : "The idea is that you, for lack of a better term, plant yourself.  Crafting and digging don't count because they presume a certain amount of movement during the task.  The handheld game does count.",
+        "description" : "It's about time you started developing a root system.  When reading, fishing, waiting, or otherwise being stationary for a while on diggable terrain, you'll extract nutrients and water from the soil.",
+        "types" : ["LEGS"],
+        "prereqs" : ["ROOTS1"],
+        "threshreq" : ["THRESH_PLANT"],
+        "changes_to" : ["ROOTS3"],
+        "category" : ["PLANT"],
+        "encumbrance_covered" : [
+            [ "FOOT_L", 10 ],
+            [ "FOOT_R", 10 ]
+        ]
+    },{
+        "type" : "mutation",
+        "id" : "ROOTS3",
+        "name" : "Rooter",
+        "points" : -3,
+        "visibility" : 5,
+        "ugliness" : 5,
+        "description" : "You find it difficult not to sink roots when able.  You extract nutrients and water whenever on diggable terrain, but move more slowly.",
+        "types" : ["LEGS"],
+        "prereqs" : ["ROOTS2"],
+        "prereqs2" : ["SAPROPHAGE"],
+        "threshreq" : ["THRESH_PLANT"],
+        "category" : ["PLANT"],
+        "encumbrance_covered" : [
+            [ "FOOT_L", 10 ],
+            [ "FOOT_R", 10 ]
+        ]
+    },{
+        "type" : "mutation",
+        "id" : "CHLOROMORPH",
+        "name" : "Chloromorphosis",
+        "points" : 10,
+        "visibility" : 7,
+        "ugliness" : 1,
+        "description" : "Every inch of your skin is packed with chlorophyll and you have strong roots.  Sleeping on diggable soil will satisfy any hunger or thirst you might have.",
+        "valid" : false,
+        "purifiable" : false,
+        "types" : ["LEGS"],
+        "prereqs" : ["ROOTS2", "ROOTS3"],
+        "prereqs2" : ["SAPROPHAGE"],
+        "threshreq" : ["THRESH_PLANT"],
+        "cancels" : ["SMELLY", "SMELLY2"],
+        "category" : ["PLANT"],
+        "encumbrance_covered" : [
+            [ "FOOT_L", 10 ],
+            [ "FOOT_R", 10 ]
+        ]
+    },{
+        "type" : "mutation",
+        "id" : "COLDBLOOD",
+        "name" : "Heat Dependent",
+        "points" : 0,
+        "mixed_effect" : true,
+        "description" : "Your muscle response is dependent on ambient temperatures.  You lose 1% of your speed for every 5 (2.8) degrees below 65 F (18.3 C).  This sluggishness helps you conserve energy, however.",
+        "changes_to" : ["COLDBLOOD2"],
+        "types" : ["METABOLISM"],
+        "category" : ["FISH", "CEPHALOPOD", "SPIDER"],
+        "metabolism_modifier": -0.333
+    },{
+        "type" : "mutation",
+        "id" : "COLDBLOOD2",
+        "name" : "Very Heat Dependent",
+        "points" : -2,
+        "mixed_effect" : true,
+        "description" : "Your muscle response is highly dependent on ambient temperatures.  You lose 1% of your speed for every 3 (1.7) degrees below 65 F (18.3 C), but your slow metabolism requires much less food.",
+        "prereqs" : ["COLDBLOOD"],
+        "changes_to" : ["COLDBLOOD3"],
+        "types" : ["METABOLISM"],
+        "category" : ["RAPTOR"],
+        "metabolism_modifier": -0.5
+    },{
+        "type" : "mutation",
+        "id" : "COLDBLOOD3",
+        "name" : "Cold Blooded",
+        "points" : -3,
+        "mixed_effect" : true,
+        "description" : "You are cold-blooded and rely on heat to keep moving.  Your lose 1% of your speed for every 2 (1.1) degrees below 65 F (18.3 C), but only need to eat about half as much as before.",
+        "prereqs" : ["COLDBLOOD2"],
+        "changes_to" : ["COLDBLOOD4"],
+        "types" : ["METABOLISM"],
+        "category" : ["INSECT", "LIZARD"],
+        "metabolism_modifier": -0.5
+    },{
+        "type" : "mutation",
+        "id" : "COLDBLOOD4",
+        "name" : "Ectothermic",
+        "points" : 0,
+        "mixed_effect" : true,
+        "description" : "Your body has become permanently cold-blooded.  Your speed lowers--or raises--for every 2 (1.1) degrees below or above 65 F (18.3 C).  You only need to eat half as much as an average human.",
+        "prereqs" : ["COLDBLOOD3"],
+        "threshreq" : ["THRESH_LIZARD"],
+        "purifiable" : false,
+        "types" : ["METABOLISM"],
+        "category" : ["LIZARD"],
+        "metabolism_modifier": -0.5
+    },{
+        "type" : "mutation",
+        "id" : "GROWL",
+        "name" : "Growling Voice",
+        "points" : -1,
+        "mixed_effect" : true,
+        "description" : "You have a growling, rough voice.  Persuading NPCs will be more difficult, but threatening them will be easier.",
+        "changes_to" : ["SNARL"],
+        "category" : ["RAT", "URSINE", "LUPINE"],
+        "social_modifiers" : {
+            "persuade" : -20,
+            "lie" : -10,
+            "intimidate" : 10
+        }
+    },{
+        "type" : "mutation",
+        "id" : "SNARL",
+        "name" : "Snarling Voice",
+        "points" : -2,
+        "mixed_effect" : true,
+        "description" : "You have a threatening snarl in your voice.  Persuading NPCs will be near impossible, but threatening them will be much easier.",
+        "prereqs" : ["GROWL"],
+        "category" : ["BEAST", "CHIMERA", "FELINE", "LUPINE"],
+        "social_modifiers" : {
+            "persuade" : -60,
+            "lie" : -40,
+            "intimidate" : 20
+        }
+    },{
+        "type" : "mutation",
+        "id" : "HISS",
+        "name": "Hissing Voice",
+        "mixed_effect" : true,
+        "points": -1,
+        "description": "You hiss when speaking.  Persuading NPCs will be more difficult, but threatening them will be easier.",
+        "category": ["LIZARD", "RAPTOR"],
+        "social_modifiers" : {
+            "persuade" : -20,
+            "lie" : -10,
+            "intimidate" : 10
+        }
+    },{
+        "type" : "mutation",
+        "id" : "SHOUT1",
+        "name" : "Shouter",
+        "points" : -2,
+        "description" : "You occasionally shout uncontrollably.",
+        "changes_to" : ["SHOUT2"],
+        "category" : ["RAPTOR"]
+    },{
+        "type" : "mutation",
+        "id" : "SHOUT2",
+        "name" : "Screamer",
+        "points" : -3,
+        "description" : "You sometimes scream uncontrollably.",
+        "prereqs" : ["SHOUT1"],
+        "changes_to" : ["SHOUT3"],
+        "category" : ["BEAST"]
+    },{
+        "type" : "mutation",
+        "id" : "SHOUT3",
+        "name" : "Howler",
+        "points" : -4,
+        "description" : "You frequently let out a piercing howl.",
+        "prereqs" : ["SHOUT2"],
+        "category" : ["CHIMERA", "LUPINE"]
+    },{
+        "type" : "mutation",
+        "id" : "ARM_FEATHERS",
+        "name" : "Feathered Arms",
+        "points" : -2,
+        "visibility" : 8,
+        "ugliness" : 2,
+        "description" : "Your arms have grown vibrantly colored feathers.  They effectively waterproof your arms and take the edge off hits, but really get in the way.  They're simply too small to help you in the air.",
+        "category" : ["RAPTOR"],
+        "wet_protection" : [
+            { "part" : "ARM_L", "neutral" : 50 },
+            { "part" : "ARM_R", "neutral" : 50 },
+            { "part" : "HAND_L", "neutral" : 10 },
+            { "part" : "HAND_R", "neutral" : 10 }
+        ],
+        "encumbrance_always" : [
+            [ "ARM_L", 20 ],
+            [ "ARM_R", 20 ]
+        ],
+        "armor" : [ { "parts" : [ "ARM_L", "ARM_R" ], "bash" : 1 } ]
+    },{
+        "type" : "mutation",
+        "id" : "INSECT_ARMS",
+        "name" : "Insect Limbs",
+        "points" : -5,
+        "visibility" : 8,
+        "ugliness" : 5,
+        "description" : "You've *finally* sprouted a pair of arms from your midsection.  They flail more-or-less uncontrollably, making you feel rather larval.",
+        "purifiable" : false,
+        "encumbrance_always" : [
+            [ "ARM_L", 30 ],
+            [ "ARM_R", 30 ]
+        ],
+        "types" : ["HANDS"],
+        "changes_to" : ["INSECT_ARMS_OK", "ARACHNID_ARMS"],
+        "prereqs" : ["CHITIN", "CHITIN2", "CHITIN3", "CHITIN_FUR2", "CHITIN_FUR3"],
+        "prereqs2" : ["ANTENNAE"],
+        "threshreq" : ["THRESH_INSECT", "THRESH_SPIDER"],
+        "category" : ["INSECT", "SPIDER"],
+        "restricts_gear" : [ "TORSO" ]
+    },{
+        "type" : "mutation",
+        "id" : "INSECT_ARMS_OK",
+        "name" : "Insect Arms",
+        "points" : 0,
+        "visibility" : 4,
+        "ugliness" : 5,
+        "description" : "It's good having all your arms.  Though they're too thin to block or punch, you can fold them inside human-shaped gear if need be.",
+        "valid" : false,
+        "purifiable" : false,
+        "types" : ["HANDS"],
+        "prereqs" : ["INSECT_ARMS"],
+        "prereqs2" : ["ANTENNAE"],
+        "threshreq" : ["THRESH_INSECT"],
+        "category" : ["INSECT"]
+    },{
+        "type" : "mutation",
+        "id" : "ARACHNID_ARMS",
+        "name" : "Arachnid Limbs",
+        "points" : -7,
+        "visibility" : 10,
+        "ugliness" : 10,
+        "description" : "There's the last two limbs you were expecting.  Unfortunately you still can't coordinate them, so you're getting in your own way.  A lot.",
+        "valid" : false,
+        "purifiable" : false,
+        "encumbrance_always" : [
+            [ "ARM_L", 40 ],
+            [ "ARM_R", 40 ]
+        ],
+        "types" : ["HANDS"],
+        "changes_to" : ["ARACHNID_ARMS_OK"],
+        "prereqs" : ["INSECT_ARMS"],
+        "prereqs2" : ["CHITIN3", "CHITIN_FUR2", "CHITIN_FUR3"],
+        "threshreq" : ["THRESH_SPIDER"],
+        "category" : ["SPIDER"],
+        "restricts_gear" : [ "TORSO" ]
+    },{
+        "type" : "mutation",
+        "id" : "ARACHNID_ARMS_OK",
+        "name" : "Arachnid Arms",
+        "points" : 0,
+        "visibility" : 6,
+        "ugliness" : 10,
+        "description" : "You have four handsome limbs, and then those mutant 'hand' and 'foot' things.  They probably aren't worth concealing.",
+        "valid" : false,
+        "purifiable" : false,
+        "types" : ["HANDS"],
+        "prereqs" : ["ARACHNID_ARMS"],
+        "prereqs2" : ["POISONOUS", "POISONOUS2", "WEB_RAPPEL"],
+        "threshreq" : ["THRESH_SPIDER"],
+        "category" : ["SPIDER"]
+    },{
+        "type" : "mutation",
+        "id" : "ARM_TENTACLES",
+        "name" : "Tentacle Arms",
+        "points" : -4,
+        "visibility" : 7,
+        "ugliness" : 4,
+        "mixed_effect" : true,
+        "description" : "Your arms have transformed into tentacles, resulting in a bonus of 1 to Dexterity, permanent hand encumbrance of 30, and inability to wear gloves.  Somewhat decreases wet penalties.",
+        "encumbrance_always" : [
+            [ "HAND_L", 30 ],
+            [ "HAND_R", 30 ]
+        ],
+        "restricts_gear" : [ "HAND_L", "HAND_R" ],
+        "types" : ["HANDS"],
+        "leads_to" : ["CLAWS_TENTACLE"],
+        "changes_to" : ["ARM_TENTACLES_4"],
+        "cancels" : ["NAILS", "CLAWS", "TALONS", "WEBBED"],
+        "wet_protection" : [
+            { "part" : "ARM_L", "neutral" : 19 },
+            { "part" : "ARM_R", "neutral" : 19 },
+            { "part" : "HAND_L", "neutral" : 5 },
+            { "part" : "HAND_R", "neutral" : 5 }
+        ],
+        "attacks": [
+            {
+                "attack_text_u" : "You slap %s with your tentacle",
+                "attack_text_npc" : "%1$s slaps %2$s with their tentacle",
+                "blocker_mutations" : [ "CLAWS_TENTACLE" ],
+                "chance" : 1,
+                "hardcoded_effect" : true
+            },
+            {
+                "attack_text_u" : "You rake %s with your tentacle",
+                "attack_text_npc" : "%1$s rakes %2$s with their tentacle",
+                "required_mutations" : [ "CLAWS_TENTACLE" ],
+                "chance" : 1,
+                "hardcoded_effect" : true
+            }
+        ]
+    },{
+        "type" : "mutation",
+        "id" : "ARM_TENTACLES_4",
+        "name" : "4 Tentacles",
+        "points" : -2,
+        "visibility" : 8,
+        "ugliness" : 5,
+        "description" : "Your arms have transformed into four tentacles, resulting in a bonus of 1 to Dexterity, permanent hand encumbrance of 30, and inability to wear gloves.  You can make up to 3 extra attacks with them.  Somewhat decreases wet penalties.",
+        "encumbrance_always" : [
+            [ "HAND_L", 30 ],
+            [ "HAND_R", 30 ]
+        ],
+        "restricts_gear" : [ "HAND_L", "HAND_R" ],
+        "types" : ["HANDS"],
+        "prereqs" : ["ARM_TENTACLES"],
+        "leads_to" : ["CLAWS_TENTACLE"],
+        "changes_to" : ["ARM_TENTACLES_8"],
+        "wet_protection" : [
+            { "part" : "ARM_L", "neutral" : 19 },
+            { "part" : "ARM_R", "neutral" : 19 },
+            { "part" : "HAND_L", "neutral" : 5 },
+            { "part" : "HAND_R", "neutral" : 5 }
+        ],
+        "attacks": [
+            {
+                "attack_text_u" : "You slap %s with your tentacle",
+                "attack_text_npc" : "%1$s slaps %2$s with their tentacle",
+                "blocker_mutations" : [ "CLAWS_TENTACLE" ],
+                "chance" : 1,
+                "hardcoded_effect" : true
+            },
+            {
+                "attack_text_u" : "You rake %s with your tentacle",
+                "attack_text_npc" : "%1$s rakes %2$s with their tentacle",
+                "required_mutations" : [ "CLAWS_TENTACLE" ],
+                "chance" : 1,
+                "hardcoded_effect" : true
+            }
+        ]
+    },{
+        "type" : "mutation",
+        "id" : "ARM_TENTACLES_8",
+        "name" : "8 Tentacles",
+        "points" : -1,
+        "visibility" : 9,
+        "ugliness" : 6,
+        "description" : "Your arms have transformed into eight tentacles, resulting in a bonus of 1 to Dexterity, permanent hand encumbrance of 30, and inability to wear gloves.  You can make up to 7 extra attacks with them.  Somewhat decreases wet penalties.",
+        "encumbrance_always" : [
+            [ "HAND_L", 30 ],
+            [ "HAND_R", 30 ]
+        ],
+        "restricts_gear" : [ "HAND_L", "HAND_R" ],
+        "types" : ["HANDS"],
+        "prereqs" : ["ARM_TENTACLES_4"],
+        "leads_to" : ["CLAWS_TENTACLE"],
+        "category" : ["CEPHALOPOD"],
+        "wet_protection" : [
+            { "part" : "ARM_L", "neutral" : 19 },
+            { "part" : "ARM_R", "neutral" : 19 },
+            { "part" : "HAND_L", "neutral" : 5 },
+            { "part" : "HAND_R", "neutral" : 5 }
+        ],
+        "attacks": [
+            {
+                "attack_text_u" : "You slap %s with your tentacle",
+                "attack_text_npc" : "%1$s slaps %2$s with their tentacle",
+                "blocker_mutations" : [ "CLAWS_TENTACLE" ],
+                "chance" : 1,
+                "hardcoded_effect" : true
+            },
+            {
+                "attack_text_u" : "You rake %s with your tentacle",
+                "attack_text_npc" : "%1$s rakes %2$s with their tentacle",
+                "required_mutations" : [ "CLAWS_TENTACLE" ],
+                "chance" : 1,
+                "hardcoded_effect" : true
+            }
+        ]
+    },{
+        "type" : "mutation",
+        "id" : "SHELL",
+        "name" : "Shell",
+        "points" : -5,
+        "visibility" : 8,
+        "ugliness" : 3,
+        "description" : "You have grown a thick shell over your torso, providing excellent armor.  You find you can use the empty space as 16 storage space, but cannot wear anything on your torso.  Somewhat reduces wet effects.",
+        "prereqs" : ["CHITIN"],
+        "cancels" : ["CHITIN3"],
+        "changes_to" : ["SHELL2"],
+        "category" : ["CEPHALOPOD"],
+        "wet_protection" : [
+            { "part" : "TORSO", "ignored" : 26 }
+        ],
+        "restricts_gear" : [ "TORSO" ],
+        "destroys_gear" : true,
+        "armor" : [ { "parts" : "TORSO", "bash" : 6, "cut" : 14 } ]
+    },{
+        "type" : "mutation",
+        "id" : "SHELL2",
+        "name" : "Roomy Shell",
+        "points" : -1,
+        "visibility" : 10,
+        "ugliness" : 3,
+        "bodytemp_modifiers" : [500, 750],
+        "bodytemp_sleep" : 200,
+        "mixed_effect" : true,
+        "description" : "Your protective shell has grown large enough to accommodate--if need be--your whole body.  Activate to pull your head and limbs into your shell, trading mobility and vision for warmth and shelter.",
+        "encumbrance_always" : [[ "TORSO", 10 ]],
+        "prereqs" : ["SHELL"],
+        "threshreq" : ["THRESH_CEPHALOPOD"],
+        "category" : ["CEPHALOPOD"],
+        "wet_protection" : [
+            { "part" : "TORSO", "ignored" : 26 }
+        ],
+        "active"     :    true,
+        "restricts_gear" : [ "TORSO" ],
+        "destroys_gear" : true,
+        "armor" : [ { "parts" : "TORSO", "bash" : 9, "cut" : 17 } ]
+    },{
+        "type" : "mutation",
+        "id" : "LEG_TENTACLES",
+        "name" : "Leg Tentacles",
+        "points" : -4,
+        "visibility" : 8,
+        "ugliness" : 4,
+        "mixed_effect" : true,
+        "description" : "Your legs have transformed into six tentacles.  This decreases your speed on land by 20%, makes your movement silent, increases your swimming speed, and reduces wet penalties.",
+        "types" : ["LEGS"],
+        "leads_to" : ["LEG_TENT_BRACE"],
+        "category" : ["CEPHALOPOD"],
+        "wet_protection" : [
+            { "part" : "LEG_L", "neutral" : 21 },
+            { "part" : "LEG_R", "neutral" : 21 },
+            { "part" : "FOOT_L", "neutral" : 6 },
+            { "part" : "FOOT_R", "neutral" : 6 }
+        ],
+        "restricts_gear" : [ "FOOT_L", "FOOT_R" ]
+    },{
+        "type" : "mutation",
+        "id" : "LEG_TENT_BRACE",
+        "name" : "Tentacle Bracing",
+        "points" : -1,
+        "visibility" : 4,
+        "ugliness" : 2,
+        "mixed_effect" : true,
+        "description" : "Your lower-tentacles have developed suckers.  They make land movement marginally more tiring, but do a good job of keeping you set in place.",
+        "prereqs" : ["LEG_TENTACLES"],
+        "threshreq" : ["THRESH_CEPHALOPOD"],
+        "category" : ["CEPHALOPOD"]
+    },{
+        "type" : "mutation",
+        "id" : "THRESH_LIZARD",
+        "name" : "Lizard",
+        "points" : 1,
+        "description" : "You sometimes look back on your days before your tail came in.  But you're better now.",
+        "valid": false,
+        "purifiable": false,
+        "threshold": true
+    },{
+        "type" : "mutation",
+        "id" : "THRESH_BIRD",
+        "name" : "Bird",
+        "points" : 1,
+        "description" : "You're sure you'll fly someday.  In the meantime, there are still nests to build.",
+        "valid": false,
+        "purifiable": false,
+        "threshold": true
+    },{
+        "type" : "mutation",
+        "id" : "THRESH_FISH",
+        "name" : "Aquatic",
+        "points" : 1,
+        "description" : "Ninety percent of the planet, and it's yours to explore.  And colonize.  And enjoy.  What was that about a surface?",
+        "valid": false,
+        "purifiable": false,
+        "threshold": true
+    },{
+        "type" : "mutation",
+        "id" : "THRESH_BEAST",
+        "name" : "Beast",
+        "points" : 1,
+        "description" : "It's about time you grew out.  Now that you've matured, it is time to make something of yourself.",
+        "valid": false,
+        "purifiable": false,
+        "threshold": true
+    },{
+        "type" : "mutation",
+        "id" : "THRESH_FELINE",
+        "name" : "Feline",
+        "points" : 1,
+        "description" : "Stalking prey, eating well, and lying in the sun.  Mmm, all you could ever desire.",
+        "valid": false,
+        "purifiable": false,
+        "threshold": true
+    },{
+        "type" : "mutation",
+        "id" : "THRESH_LUPINE",
+        "name" : "Wolf",
+        "points" : 1,
+        "description" : "You're the perfect candidate to lead a pack.",
+        "valid": false,
+        "purifiable": false,
+        "threshold": true
+    },{
+        "type" : "mutation",
+        "id" : "THRESH_URSINE",
+        "name" : "Bear",
+        "points" : 1,
+        "description" : "So the humans died, what's the worry?  Now they won't ruin the woods.",
+        "cancels" : ["CARNIVORE"],
+        "valid": false,
+        "purifiable": false,
+        "threshold": true
+    },{
+        "type" : "mutation",
+        "id" : "THRESH_CATTLE",
+        "name" : "Bovine",
+        "points" : 1,
+        "description" : "Civilization collapsed?  Great!  You and your kin will never have to worry about a slaughterhouse again.",
+        "valid": false,
+        "purifiable": false,
+        "threshold": true
+    },{
+        "type" : "mutation",
+        "id" : "THRESH_INSECT",
+        "name" : "Insect",
+        "points" : 1,
+        "description" : "It would be good to be a Queen, having workers constantly servicing your every need...but how would you keep them in line?",
+        "valid": false,
+        "purifiable": false,
+        "threshold": true
+    },{
+        "type" : "mutation",
+        "id" : "THRESH_PLANT",
+        "name" : "Plant",
+        "points" : 1,
+        "description" : "Well, you still have those other walking flowers-and the mushrooms too-to deal with.  But you'll manage.",
+        "valid": false,
+        "purifiable": false,
+        "threshold": true
+    },{
+        "type" : "mutation",
+        "id" : "THRESH_SLIME",
+        "name" : "Aqueous",
+        "points" : 1,
+        "description" : "What was that old advertisement, 'paint the planet'? That might be a good long-term goal, but for now...",
+        "valid": false,
+        "purifiable": false,
+        "threshold": true
+    },{
+        "type" : "mutation",
+        "id" : "THRESH_TROGLOBITE",
+        "name" : "Subterranean",
+        "points" : 1,
+        "description" : "Not much point to rebuilding up in that horribly bright roofless wasteland.  Now that you've become accustomed to your new digs, there's the beginnings of a great empire right here, underground.",
+        "valid": false,
+        "purifiable": false,
+        "threshold": true
+    },{
+        "type" : "mutation",
+        "id" : "THRESH_CEPHALOPOD",
+        "name" : "Cephalopod",
+        "points" : 1,
+        "description" : "Strange aeons, true, but Death seems to be slacking and you are doing just fine.",
+        "valid": false,
+        "purifiable": false,
+        "threshold": true
+    },{
+        "type" : "mutation",
+        "id" : "THRESH_SPIDER",
+        "name" : "Arachnid",
+        "points" : 1,
+        "description" : "Well, maybe you'll just have to make your own world wide web.",
+        "valid": false,
+        "purifiable": false,
+        "threshold": true
+    },{
+        "type" : "mutation",
+        "id" : "THRESH_RAT",
+        "name" : "Survivor",
+        "points" : 1,
+        "description" : "Hey.  Civilization fell.  You're still around.  'Rat' just isn't respectful.",
+        "valid": false,
+        "purifiable": false,
+        "threshold": true
+    },{
+        "type" : "mutation",
+        "id" : "THRESH_MEDICAL",
+        "name" : "Prototype",
+        "points" : 1,
+        "description" : "After all those experiments, what's a few more, hmm?",
+        "valid": false,
+        "purifiable": false,
+        "threshold": true
+    },{
+        "type" : "mutation",
+        "id" : "THRESH_ALPHA",
+        "name" : "Prime",
+        "points" : 1,
+        "description" : "You're the perfect candidate to tidy this mess.",
+        "valid": false,
+        "purifiable": false,
+        "threshold": true
+    },{
+        "type" : "mutation",
+        "id" : "THRESH_ELFA",
+        "name" : "Fey",
+        "points" : 1,
+        "description" : "You are the tree under which humankind will shelter during these dark times.",
+        "valid": false,
+        "purifiable": false,
+        "threshold": true
+    },{
+        "type" : "mutation",
+        "id" : "THRESH_CHIMERA",
+        "name" : "Chaos",
+        "points" : 1,
+        "description" : "You can't tell what you are anymore.  Everything and yet nothing, like you weren't meant to exist.  But you do, and you're a force, no matter what happens.",
+        "valid": false,
+        "purifiable": false,
+        "threshold": true
+    },{
+        "type" : "mutation",
+        "id" : "THRESH_RAPTOR",
+        "name" : "Raptor",
+        "points" : 1,
+        "description" : "The chance to undo not one but TWO extinction events.  You're confident you'll do fine.",
+        "valid": false,
+        "purifiable": false,
+        "threshold": true
+    },{
+        "type" : "mutation",
+        "id" : "THRESH_MOUSE",
+        "name" : "Diminutive",
+        "points" : 1,
+        "description" : "So much food, everywhere!  And nobody's even guarding it anymore!  These are good times.",
+        "valid": false,
+        "purifiable": false,
+        "threshold": true
+    },{
+        "type" : "mutation",
+        "id" : "THRESH_MARLOSS",
+        "name" : "Marloss Gateway",
+        "points" : 1,
+        "description" : "You get the feeling that you're on the cusp of becoming something greater than yourself.",
+        "valid": false,
+        "purifiable": false,
+        "threshold": true,
+        "category" : ["MARLOSS"]
+    },{
+        "type" : "mutation",
+        "id" : "THRESH_MYCUS",
+        "name" : "Mycus",
+        "points" : 1,
+        "description" : "We are the Mycus.",
+        "valid": false,
+        "purifiable": false,
+        "threshold": true
+    },{
+        "type" : "mutation",
+        "id" : "ACIDPROOF",
+        "name" : "Acidproof",
+        "points" : 3,
+        "description" : "Your mutated flesh is immune to the damaging effects of acid.",
+        "threshreq" : ["THRESH_INSECT", "THRESH_CHIMERA", "THRESH_MEDICAL", "THRESH_SLIME"],
+        "category" : ["INSECT", "CHIMERA", "MEDICAL", "SLIME"]
+    },{
+        "type" : "mutation",
+        "id" : "ACIDBLOOD",
+        "name" : "Acid Blood",
+        "points" : 4,
+        "description" : "Your body has developed a wonderful defense mechanism.  Instead of normal blood, you bleed a strong molecular acid which will damage any creature foolish enough to harm you.",
+        "prereqs" : ["ACIDPROOF"],
+        "threshreq" : ["THRESH_INSECT", "THRESH_CHIMERA", "THRESH_MEDICAL", "THRESH_SLIME"],
+        "category" : ["INSECT", "CHIMERA", "MEDICAL", "SLIME"]
+    },{
+        "type" : "mutation",
+        "id" : "PYROMANIA",
+        "name" : "Pyromaniac",
+        "starting_trait" : true,
+        "points" : -2,
+        "description" : "You have an unhealthy obsession with fire, and you get anxious if you don't light them every now and then or stand near them often.  However, you gain a mood bonus from doing so."
+    },{
+        "type" : "mutation",
+        "id" : "AMPHIBIAN",
+        "name" : "Amphibious",
+        "points" : 5,
+        "description" : "You're as comfortable in water as on land, and your body has adapated around that fact.  Your base swimming speed is greatly increased, and weight will hinder you much less while swimming.",
+        "category" : ["FISH"],
+        "threshreq" : ["THRESH_FISH"],
+        "purifiable": false
+    },{
+        "type" : "mutation",
+        "id" : "SEESLEEP",
+        "name" : "Lidless Eyes",
+        "points" : 2,
+        "visibility" : 3,
+        "ugliness" : 4,
+        "description" : "Like a true fish, your eyes lack eyelids, and are are instead covered by a translucent, protective membrane that blocks irritants and water, and provides minor armor.  It also allows you to sleep with your eyes open!  Activate to cause the approach of hostile creatures to wake you up.",
+        "category" : ["FISH"],
+        "threshreq" : ["THRESH_FISH"],
+        "armor" : [ { "parts" : "EYES", "cut" : 3, "bash" : 1 } ],
+        "active" : true
+    },{
+        "type" : "mutation",
+        "id" : "WATERSLEEP",
+        "name" : "Aqueous Repose",
+        "points" : 1,
+        "description" : "Falling asleep underwater is easy for you, and you spend less time asleep when you rest there.  You can also eat underwater, though you can't drink.",
+        "prereqs" : ["SEESLEEP"],
+        "category" : ["FISH"],
+        "threshreq" : ["THRESH_FISH"]
+    },{
+        "type" : "mutation",
+        "id" : "TOXICFLESH",
+        "name" : "Toxic Flesh",
+        "points" : 1,
+        "description" : "Your flesh is highly poisonous, and creatures that bite you will receive a nasty surprise.",
+        "category" : ["FISH"],
+        "threshreq" : ["THRESH_FISH"],
+        "purifiable" : false
+    },{
+        "type" : "mutation",
+        "id" : "FRESHWATEROSMOSIS",
+        "name" : "Freshwater Osmosis",
+        "points" : 4,
+        "description" : "Your gills and skin are highly permeable to moisture, and you can hydrate your body through osmosis.  While submerged in fresh water, any thirst you might have will be slaked.",
+        "prereqs" : ["GILLS"],
+        "category" : ["FISH"],
+        "threshreq" : ["THRESH_FISH"]
+    },{
+        "type" : "mutation",
+        "id" : "ELECTRORECEPTORS",
+        "name" : "Electroreceptors",
+        "points" : 2,
+        "description" : "A network of jelly-filled electroreceptors, like that of a shark, have grown throughout your face and nose.  They are very sensitive to magnetic fields, allowing you to see robots and creatures charged with electricity through walls, but being shocked will seriously mess you up.",
+        "category" : ["FISH"],
+        "mixed_effect" : true
+    },{
+        "type" : "mutation",
+        "id" : "SHARKTEETH",
+        "name" : "Shark Teeth",
+        "points" : 3,
+        "visibility" : 10,
+        "ugliness" : 8,
+        "description" : "Your teeth have grown incredibly sharp and are formed of very dense calcium material.  In addition to making you eat much faster, you can use them as a lethal natural weapon, as long as your anatomy favors it.  They also grow very fast, and you harmlessly shed them more or less at random.",
+        "prereqs" : ["FANGS"],
+        "types" : ["TEETH"],
+        "category" : ["FISH"],
+        "threshreq" : ["THRESH_FISH"],
+        "social_modifiers" : {
+            "intimidate" : 5
+        },
+        "attacks" : {
+            "attack_text_u" : "You tear into %s with your teeth",
+            "attack_text_npc" : "%1$s tears into %2$s with their teeth",
+            "body_part" : "MOUTH",
+            "blocker_mutations" : [ "MUZZLE", "MUZZLE_LONG", "MUZZLE_RAT" ],
+            "chance" : 20,
+            "base_damage" : { "damage_type" : "stab", "amount" : 25 }
+        },
+        "purifiable" : false
+    },{
+        "type" : "mutation",
+        "id" : "PROF_POLICE",
+        "name" : "Police Officer",
+        "points" : 0,
+        "description" : "You are a duly sworn law enforcement officer, with jurisdiction throughout the New England region thanks to interstate agreements.  Whether that means anything now is another question.",
+        "valid": false,
+        "purifiable": false,
+        "profession": true
+    },{
+        "type" : "mutation",
+        "id" : "PROF_SWAT",
+        "name" : "SWAT Officer",
+        "points" : 0,
+        "description" : "You are a duly sworn law enforcer, with jurisdiction throughout the New England region thanks to interstate agreements.  Whether that means anything now is another question.",
+        "valid": false,
+        "purifiable": false,
+        "profession": true
+    },{
+        "type" : "mutation",
+        "id" : "PROF_CYBERCOP",
+        "name" : "Bionic Officer",
+        "points" : 0,
+        "description" : "You are a cybernetically-resurrected law enforcer, with jurisdiction throughout the New England region thanks to interstate agreements.  Whether you can do for the law what the law did for you is another question.",
+        "valid": false,
+        "purifiable": false,
+        "profession": true
+    },{
+        "type" : "mutation",
+        "id" : "PROF_CHURL",
+        "name" : "Churl",
+        "points" : 0,
+        "description" : "Thou art a lewede man, a lowly cowherd, though where thi catel been thou hast not ynn certain.",
+        "valid": false,
+        "purifiable": false,
+        "profession": true
+    },{
+        "type" : "mutation",
+        "id" : "PROF_PD_DET",
+        "name" : "Police Detective",
+        "points" : 0,
+        "description" : "You are a duly sworn law enforcement investigator, with jurisdiction throughout the New England region thanks to interstate agreements.  Whether your shield means anything now is another question.",
+        "valid": false,
+        "purifiable": false,
+        "profession": true
+    },{
+        "type" : "mutation",
+        "id" : "PROF_FED",
+        "name" : "US Marshal",
+        "points" : 0,
+        "description" : "You are a duly sworn Federal marshal, with nationwide jurisdiction and the authority of the United States of America.",
+        "valid": false,
+        "purifiable": false,
+        "profession": true
+    },{
+        "type" : "mutation",
+        "id" : "PROF_MED",
+        "name" : "MD",
+        "points" : 0,
+        "//" : "In the US, a medical 'residency' is essentially an extended post-graduate, on-the-job medical training.  The idea here is that hopsital computer systems would recognize the PC as a valid user and grant access.",
+        "description" : "You were just through with the administrative formalities for your residency when the Cataclysm struck.  \"Your\" hospital was overrun and evacuated, but there's always work for a good doctor.",
+        "valid": false,
+        "purifiable": false,
+        "profession": true
+    },{
+        "type" : "mutation",
+        "id" : "PROF_SKATER",
+        "name" : "Skater",
+        "points" : 0,
+        "description" : "You spent a lot of time actively maneuvering on skates before the Cataclysm, and are better at staying on your feet when checked or blocked.",
+        "valid": false,
+        "purifiable": false,
+        "profession": true
+    },{
+        "type" : "mutation",
+        "id" : "PROF_MA_ORANGE",
+        "name" : "Martial Artist",
+        "points" : 0,
+        "description" : "You were shaping up to be a pretty decent student of the martial arts before the Cataclysm struck.  Time to see just how good you really are.",
+        "valid": false,
+        "initial_ma_styles" : [ "style_karate", "style_judo", "style_muay_thai", "style_tai_chi", "style_taekwondo" ],
+        "purifiable": false,
+        "profession": true
+    },{
+        "type" : "mutation",
+        "id" : "PROF_MA_BLACK",
+        "name" : "Black Belt",
+        "points" : 0,
+        "description" : "You were competitive at national levels, and had considered teaching your art.  Defending against the entire town may still be a challenge, though.",
+        "initial_ma_styles" : [ "style_karate", "style_judo", "style_aikido", "style_tai_chi", "style_taekwondo", "style_zui_quan", "style_muay_thai" ],
+        "valid": false,
+        "purifiable": false,
+        "profession": true
+    },{
+        "type" : "mutation",
+        "id" : "PROF_BOXER",
+        "name" : "Pugilist",
+        "points" : 0,
+        "description" : "You are experienced in the Sweet Science of boxing.  You could've had a shot at a local boxing tournament, if the Cataclysm hadn't screwed that up.",
+        "valid": false,
+        "initial_ma_styles" : [ "style_boxing" ],
+        "purifiable": false,
+        "profession": true
+    },{
+        "type" : "mutation",
+        "id" : "PROF_AUTODOC",
+        "name" : "Autodoc Specialist",
+        "points" : 0,
+        "description" : "You're trained in proper operation of the Autodoc, an advanced machine used for surgical procedures.  Operations involving it will be moderately more likely to succeed.",
+        "valid": false,
+        "purifiable": false,
+        "profession": true
+    },{
+        "type" : "mutation",
+        "id" : "PROF_DICEMASTER",
+        "name" : "Dungeon Master",
+        "points" : 0,
+        "description" : "Weeks spent picking through manuals and researching topics you aren't versed in has taught you to find what you need to know more quickly.  You read slightly faster, and suffer no reading time penalty for books too complex for you to easily understand.",
+        "valid": false,
+        "purifiable": false,
+        "profession": true,
+        "cancels": ["ILLITERATE"]
+    },{
+        "type" : "mutation",
+        "id" : "NPC_BRANDY",
+        "name" : "Carries Brandy",
+        "points" : 0,
+        "description" : "This Bartender now carries brandy!",
+        "player_display": false,
+        "valid": false,
+        "purifiable": false
+    },{
+        "type" : "mutation",
+        "id" : "NPC_RUM",
+        "name" : "Carries Rum",
+        "points" : 0,
+        "description" : "This Bartender now carries rum!",
+        "player_display": false,
+        "valid": false,
+        "purifiable": false
+    },{
+        "type" : "mutation",
+        "id" : "NPC_WHISKEY",
+        "name" : "Carries Whiskey",
+        "points" : 0,
+        "description" : "This Bartender now carries whiskey!",
+        "player_display": false,
+        "valid": false,
+        "purifiable": false
+    },{
+        "type" : "mutation",
+        "id" : "NPC_MISSION_LEV_1",
+        "name" : "Has Level 1 Companion Missions",
+        "points" : 0,
+        "description" : "New mission options have become available!",
+        "player_display": false,
+        "valid": false,
+        "purifiable": false
+    },{
+        "type" : "mutation",
+        "id" : "NPC_CONSTRUCTION_LEV_1",
+        "name" : "Has Level 1 Construction Built",
+        "points" : 0,
+        "description" : "New options may have become available!",
+        "player_display": false,
+        "valid": false,
+        "purifiable": false
+    },{
+        "type" : "mutation",
+        "id" : "NPC_CONSTRUCTION_LEV_2",
+        "name" : "Has Level 2 Construction Built",
+        "points" : 0,
+        "description" : "New options may have become available!",
+        "player_display": false,
+        "valid": false,
+        "purifiable": false
+    },
+  {
+    "type": "mutation",
+    "id": "NPC_STARTING_NPC",
+    "name": "Starting NPC",
+    "points": 0,
+    "description": "Marker for starting NPCs",
+    "player_display": false,
+    "valid": false,
+    "purifiable": false
+  },
+  {
+    "type": "mutation",
+    "id": "NPC_STATIC_NPC",
+    "name": "Static NPC",
+    "points": 0,
+    "description": "Marker for static NPCs",
+    "player_display": false,
+    "valid": false,
+    "purifiable": false
+  },
+  {
+        "type" : "mutation",
+        "id" : "DEBUG_NIGHTVISION",
+        "name" : "Debug Vision",
+        "points" : 99,
+        "valid" : false,
+        "description" : "You can clearly see that this is for dev purposes only.",
+        "debug" : true
+    },{
+        "type" : "mutation",
+        "id" : "DEBUG_CLOAK",
+        "name" : "Debug Invisibility",
+        "points" : 99,
+        "valid" : false,
+        "description" : "If you see this, you'd best be debugging something.",
+        "debug" : true
+    },{
+        "type" : "mutation",
+        "id" : "DEBUG_LS",
+        "name" : "Debug Life Support",
+        "points" : 99,
+        "valid" : false,
+        "description" : "Holds hunger, thirst, and fatigue stable.  You can debug all year long with this one!",
+        "debug" : true
+    },{
+        "type" : "mutation",
+        "id" : "DEBUG_NOSCENT",
+        "name" : "Debug Deodorizer",
+        "points" : 99,
+        "valid" : false,
+        "description" : "Smell that bug?  Smell's certainly not coming from you!",
+        "debug" : true
+    },{
+        "type" : "mutation",
+        "id" : "DEBUG_SILENT",
+        "name" : "Debug Silent Walk",
+        "points" : 99,
+        "valid" : false,
+        "description" : "Be vewwy vewwy quiet.  We're hunting bugs.",
+        "debug" : true
+    },{
+        "type" : "mutation",
+        "id" : "DEBUG_NOTEMP",
+        "name" : "Debug HVAC",
+        "points" : 99,
+        "valid" : false,
+        "description" : "Temperature and weather won't bug you.",
+        "debug" : true
+    },{
+        "type" : "mutation",
+        "id" : "DEBUG_NODMG",
+        "name" : "Debug Invincibility",
+        "points" : 99,
+        "valid" : false,
+        "description" : "Bug repellent forcefield.",
+        "debug" : true
+    },{
+        "type" : "mutation",
+        "id" : "DEBUG_HS",
+        "name" : "Debug Hammerspace",
+        "points" : 99,
+        "valid" : false,
+        "description" : "Crafting and construction requirements bugger off with this one.  Apply with care.",
+        "debug" : true
+    },{
+        "type" : "mutation",
+        "id" : "DEBUG_MIND_CONTROL",
+        "name" : "Debug Mind Control",
+        "points" : 99,
+        "valid" : false,
+        "description" : "Mind the bugs, would you kindly?",
+        "debug" : true
+    },{
+        "type" : "mutation",
+        "id" : "DEBUG_STORAGE",
+        "name" : "Debug Carrying Capacity",
+        "points" : 99,
+        "valid" : false,
+        "description" : "Lets you carry 15 bugs worth of your body weight in your mandibles.",
+        "debug" : true
+    },{
+        "type" : "mutation",
+        "id" : "DEBUG_BIONICS",
+        "name" : "Debug Bionic Installation",
+        "points" : 99,
+        "valid" : false,
+        "description" : "Lets you instantly install torsion ratchets for your eight legs.",
+        "debug" : true
+    },{
+        "type" : "mutation",
+        "id" : "DEBUG_BIONIC_POWER",
+        "name" : "Debug Bionic Power",
+        "points" : 99,
+        "valid" : false,
+        "description" : "For fueling your inner cybug.  Activate to increase power capacity by 100 (can be repeated.)",
+        "debug" : true,
+        "active" : true
+    },{
+        "type" : "mutation",
+        "id" : "SQUEAMISH",
+        "name" : "Squeamish",
+        "points" : -1,
+        "starting_trait" : true,
+        "description" : "You can't even think about putting filthy clothes on yourself, especially from zombies' corpses."
+    },{
+        "type" : "mutation",
+        "id" : "BEE",
+        "name" : "Bee",
+        "points" : 0,
+        "valid" : false,
+        "description" : "NPC trait that makes monsters see it as a bee.  It is a bug (heh) if you have it.",
+        "player_display": false,
+        "threshold" : true
+    },{
+        "type" : "mutation",
+        "id" : "MUTE",
+        "name" : "mute",
+        "points" : 0,
+        "valid" : false,
+        "description" : "NPC trait that makes it impossible to say anything.  It is a bug if you have it.",
+        "player_display": false,
+        "threshold" : true
+    }
+]

--- a/techniques.json
+++ b/techniques.json
@@ -1,0 +1,1398 @@
+[
+    {
+        "type" : "technique",
+        "id" : "tec_none",
+        "name" : "Not at technique at all",
+        "dummy" : true
+    },{
+        "type" : "technique",
+        "id" : "WBLOCK_1",
+        "name" : "Block",
+        "dummy" : true,
+        "mult_bonuses" : [["movecost", 0.0]],
+        "messages" : [
+            "You block %s",
+            "<npcname> blocks %s"
+        ],
+        "description" : "Medium blocking ability"
+    },{
+        "type" : "technique",
+        "id" : "WBLOCK_2",
+        "name" : "Parry",
+        "dummy" : true,
+        "mult_bonuses" : [["movecost", 0.0]],
+        "messages" : [
+            "You parry %s",
+            "<npcname> parries %s"
+        ],
+        "description" : "High blocking ability"
+    },{
+        "type" : "technique",
+        "id" : "WBLOCK_3",
+        "name" : "Shield",
+        "dummy" : true,
+        "mult_bonuses" : [["movecost", 0.0]],
+        "messages" : [
+            "You shield against %s",
+            "<npcname> shields against %s"
+        ],
+        "description" : "Very high blocking ability"
+    },{
+        "type" : "technique",
+        "id" : "DEF_DISARM",
+        "name" : "disarm",
+        "min_unarmed" : 0,
+        "melee_allowed" : true,
+        "disarms" : true,
+        "description" : "Unwield target's weapon"
+    },{
+        "type" : "technique",
+        "id" : "GRAB",
+        "name" : "", "//": "not implemented -> empty name",
+        "messages" : [
+            "You grab %s",
+            "<npcname> grabs %s"
+        ]
+    },{
+        "type" : "technique",
+        "id" : "SPIN",
+        "name" : "Spinning Strike",
+        "unarmed_allowed" : true,
+        "melee_allowed" : true,
+        "min_melee" : 4,
+        "crit_tec" : true,
+        "messages" : [
+            "You swing through %s and everyone nearby",
+            "<npcname> swings through %s and everyone nearby"
+        ],
+        "aoe" : "spin",
+        "description" : "Attack adjacent enemies, crit only, min 4 melee"
+    },{
+        "type" : "technique",
+        "id" : "WIDE",
+        "name" : "Wide Strike",
+        "unarmed_allowed" : true,
+        "melee_allowed" : true,
+        "min_melee" : 3,
+        "crit_tec" : true,
+        "weighting" : 2,
+        "messages" : [
+            "You swing in a wide arc through %s",
+            "<npcname> swings in a wide arc through %s"
+        ],
+        "aoe" : "wide",
+        "description" : "Attack in a wide arc, crit only, min 3 melee"
+    },{
+        "type" : "technique",
+        "id" : "IMPALE",
+        "name" : "Impaling Strike",
+        "melee_allowed" : true,
+        "min_melee" : 4,
+        "crit_tec" : true,
+        "messages" : [
+            "You pierce straight through %s",
+            "<npcname> pierces through %s"
+        ],
+        "aoe" : "impale",
+        "description" : "Attack target and another one behind it, crit only, min 4 melee"
+    },{
+        "type" : "technique",
+        "id" : "BRUTAL",
+        "name" : "Brutal Strike",
+        "unarmed_allowed" : true,
+        "melee_allowed" : true,
+        "crit_tec" : true,
+        "stun_dur" : 1,
+        "knockback_dist" : 1,
+        "messages" : [
+            "You send %s reeling",
+            "<npcname> sends %s reeling"
+        ],
+        "description" : "Stun 1 turn, knockback 1 tile, crit only"
+    },{
+        "type" : "technique",
+        "id" : "RAPID",
+        "name" : "Rapid Strike",
+        "min_unarmed" : 0,
+        "unarmed_allowed" : true,
+        "melee_allowed" : true,
+        "mult_bonuses" : [
+            ["movecost", 0.5],
+            ["damage", "bash", 0.66],
+            ["damage", "cut", 0.66],
+            ["damage", "stab", 0.66]
+        ],
+        "messages" : [
+            "You quickly strike %s",
+            "<npcname> quickly strikes %s"
+        ],
+        "description" : "50% moves, 66% damage"
+    },{
+        "type" : "technique",
+        "id" : "VORPAL",
+        "name" : "Vorpal Strike",
+        "min_unarmed" : 0,
+        "unarmed_allowed" : true,
+        "melee_allowed" : true,
+        "mult_bonuses" : [["damage", "cut", 99]],
+        "crit_tec" : true,
+        "weighting" : -250,
+        "messages" : [
+            "Snicker-snack! You slice through %s like hot knife slices through butter",
+            "Snicker-snack! <npcname> slices through %s like hot knife slices through butter"
+        ],
+        "description" : "Cut damage multiply by 99, crit only"
+    },{
+        "type" : "technique",
+        "id" : "WRAP",
+        "name" : "Wrap Attack",
+        "min_unarmed" : 0,
+        "unarmed_allowed" : true,
+        "stun_dur" : 2,
+        "messages" : [
+            "You wrap up %s",
+            "<npcname> wraps up %s"
+        ],
+        "description" : "Stun 2 turns"
+    },{
+        "type" : "technique",
+        "id" : "SWEEP",
+        "name" : "Sweep Attack",
+        "min_unarmed" : 0,
+        "unarmed_allowed" : true,
+        "down_dur" : 2,
+        "messages" : [
+            "You sweep %s",
+            "<npcname> sweeps %s"
+        ],
+        "description" : "Down 2 turns"
+    },{
+        "type" : "technique",
+        "id" : "PRECISE",
+        "name" : "Precise Strike",
+        "min_unarmed" : 0,
+        "unarmed_allowed" : true,
+        "melee_allowed" : true,
+        "crit_tec" : true,
+        "messages" : [
+            "You precisely hit %s",
+            "<npcname> precisely hits %s"
+        ],
+        "stun_dur" : 2,
+        "description" : "Stun 2 turns, crit only"
+    },{
+        "type" : "technique",
+        "id" : "WHIP_DISARM",
+        "name" : "Disarm",
+        "min_unarmed" : 0,
+        "melee_allowed" : true,
+        "disarms" : true,
+        "messages" : [
+            "You disarm %s using your whip",
+            "<npcname> disarms %s using their whip"
+        ],
+        "description" : "Unwield target's weapon"
+    },{
+        "type" : "technique",
+        "id" : "tec_counter",
+        "name" : "Counterattack",
+        "min_unarmed" : 0,
+        "unarmed_allowed" : true,
+        "block_counter": true,
+        "dodge_counter": true,
+        "mult_bonuses" : [["movecost", 0.0]],
+        "messages" : [
+            "You counter-attack %s",
+            "<npcname> counter-attacks %s"
+        ]
+    },{
+        "type" : "technique",
+        "id" : "tec_feint",
+        "name" : "Feint",
+        "unarmed_allowed" : true,
+        "melee_allowed" : true,
+        "defensive" : true,
+        "miss_recovery" : true
+    },{
+        "type" : "technique",
+        "id" : "tec_break",
+        "name" : "Grab Break",
+        "unarmed_allowed" : true,
+        "melee_allowed" : true,
+        "defensive" : true,
+        "grab_break" : true
+    },{
+        "type" : "technique",
+        "id" : "tec_precise",
+        "name" : "Precise Strike",
+        "min_unarmed" : 0,
+        "unarmed_allowed" : true,
+        "melee_allowed" : true,
+        "crit_tec" : true,
+        "messages" : [
+            "You jab deftly at %s",
+            "<npcname> jabs deftly at %s"
+        ],
+        "stun_dur" : 2
+    },{
+        "type" : "technique",
+        "id" : "tec_boxing_cross",
+        "name" : "Cross",
+        "min_unarmed" : 2,
+        "unarmed_allowed" : true,
+        "messages" : [
+            "You throw a heavy cross at %s",
+            "<npcname> throws a cross at %s"
+        ],
+        "mult_bonuses" : [["damage", "bash", 1.2]]
+    },{
+        "type" : "technique",
+        "id" : "tec_boxing_rapid",
+        "name" : "Jab",
+        "min_unarmed" : 3,
+        "unarmed_allowed" : true,
+        "messages" : [
+            "You quickly jab %s",
+            "<npcname> quickly jabs at %s"
+        ],
+        "mult_bonuses" : [
+            ["movecost", 0.5],
+            ["damage", "bash", 0.66],
+            ["damage", "cut", 0.66],
+            ["damage", "stab", 0.66]
+        ]
+    },{
+        "type" : "technique",
+        "id" : "tec_boxing_upper",
+        "name" : "Uppercut",
+        "min_unarmed" : 4,
+        "unarmed_allowed" : true,
+        "crit_tec" : true,
+        "messages" : [
+            "You uppercut %s",
+            "<npcname> uppercuts %s"
+        ],
+        "mult_bonuses" : [["damage", "bash", 1.4]],
+        "stun_dur" : 2
+    },{
+        "type" : "technique",
+        "id" : "tec_boxing_counter",
+        "name" : "Cross Counter",
+        "min_unarmed" : 5,
+        "unarmed_allowed" : true,
+        "crit_tec" : true,
+        "knockback_dist" : 1,
+        "knockback_spread" : 1,
+        "req_buffs" : [
+            "boxing_counter"
+            ],
+        "messages" : [
+            "You cross-counter %s",
+            "<npcname> throws a perfect counter at %s"
+        ],
+        "mult_bonuses" : [["movecost", 0.0]],
+        "stun_dur" : 2
+    },{
+        "type" : "technique",
+        "id" : "tec_karate_rapid",
+        "name" : "quick punch",
+        "min_unarmed" : 0,
+        "unarmed_allowed" : true,
+        "messages" : [
+            "You quickly punch %s",
+            "<npcname> quickly punches %s"
+        ],
+        "mult_bonuses" : [
+            ["movecost", 0.5],
+            ["damage", "bash", 0.66],
+            ["damage", "cut", 0.66],
+            ["damage", "stab", 0.66]
+        ]
+    },{
+        "type" : "technique",
+        "id" : "tec_karate_precise",
+        "name" : "karate chop",
+        "min_unarmed" : 4,
+        "unarmed_allowed" : true,
+        "crit_tec" : true,
+        "messages" : [
+            "You karate chop %s",
+            "<npcname> karate chops %s"
+        ],
+        "stun_dur" : 2
+    },{
+        "type" : "technique",
+        "id" : "tec_aikido_throw",
+        "name" : "throw",
+        "min_unarmed" : 2,
+        "unarmed_allowed" : true,
+        "down_dur" : 1,
+        "knockback_dist" : 1,
+        "knockback_spread" : 1,
+        "messages" : [
+            "You throw %s",
+            "<npcname> throws %s"
+        ]
+    },{
+        "type" : "technique",
+        "id" : "tec_aikido_dodgethrow",
+        "name" : "dodge throw",
+        "min_unarmed" : 6,
+        "unarmed_allowed" : true,
+        "dodge_counter": true,
+        "down_dur" : 1,
+        "knockback_dist" : 1,
+        "knockback_spread" : 1,
+        "mult_bonuses" : [["movecost", 0.0]],
+        "messages" : [
+            "You smoothly throw %s",
+            "<npcname> smoothly throws %s"
+        ]
+    },{
+        "type" : "technique",
+        "id" : "tec_aikido_feint",
+        "name" : "feint at",
+        "min_unarmed" : 2,
+        "unarmed_allowed" : true,
+        "defensive" : true,
+        "miss_recovery" : true,
+        "messages" : [
+            "You feint at %s",
+            "<npcname> feints at %s"
+        ]
+    },{
+        "type" : "technique",
+        "id" : "tec_aikido_disarm",
+        "name" : "disarm",
+        "min_unarmed" : 3,
+        "unarmed_allowed" : true,
+        "disarms" : true,
+        "messages" : [
+            "You disarm %s",
+            "<npcname> disarms %s"
+        ]
+    },{
+        "type" : "technique",
+        "id" : "tec_judo_throw",
+        "name" : "throw",
+        "min_unarmed" : 3,
+        "unarmed_allowed" : true,
+        "down_dur" : 1,
+        "knockback_dist" : 1,
+        "knockback_spread" : 1,
+        "messages" : [
+            "You throw %s",
+            "<npcname> throws %s"
+        ]
+    },{
+        "type" : "technique",
+        "id" : "tec_judo_grab",
+        "name" : "grab",
+        "min_unarmed" : 2,
+        "unarmed_allowed" : true,
+        "down_dur" : 2,
+        "messages" : [
+            "You grab %s",
+            "<npcname> grabs %s"
+        ]
+    },{
+        "type" : "technique",
+        "id" : "tec_taichi_disarm",
+        "name" : "disarm",
+        "min_unarmed" : 3,
+        "unarmed_allowed" : true,
+        "disarms" : true,
+        "messages" : [
+            "You disarm %s",
+            "<npcname> disarms %s"
+        ]
+    },{
+        "type" : "technique",
+        "id" : "tec_taichi_precise",
+        "name" : "precise strike",
+        "min_unarmed" : 4,
+        "unarmed_allowed" : true,
+        "crit_tec" : true,
+        "stun_dur" : 2,
+        "messages" : [
+            "You strike %s",
+            "<npcname> strikes %s"
+        ]
+    },{
+        "type" : "technique",
+        "id" : "tec_capoeira_feint",
+        "name" : "feint at",
+        "min_unarmed" : 1,
+        "unarmed_allowed" : true,
+        "defensive" : true,
+        "miss_recovery" : true,
+        "messages" : [
+            "You feint at %s",
+            "<npcname> feints at %s"
+        ]
+    },{
+        "type" : "technique",
+        "id" : "tec_muay_thai_elbow",
+        "name" : "elbow",
+        "min_unarmed" : 2,
+        "unarmed_allowed" : true,
+        "crit_tec" : true,
+        "messages" : [
+            "You elbow %s",
+            "<npcname> elbows %s"
+        ],
+        "mult_bonuses" : [["movecost", 0.5]]
+    },{
+        "type" : "technique",
+        "id" : "tec_muay_thai_kick",
+        "name" : "kick",
+        "min_unarmed" : 3,
+        "unarmed_allowed" : true,
+        "messages" : [
+            "You power-kick %s",
+            "<npcname> power-kicks %s"
+        ],
+        "stun_dur" : 1
+    },{
+        "type" : "technique",
+        "id" : "tec_muay_thai_knee",
+        "name" : "flying knee",
+        "min_unarmed" : 4,
+        "unarmed_allowed" : true,
+        "crit_tec" : true,
+        "messages" : [
+            "You flying knee %s",
+            "<npcname> flying knees %s"
+        ],
+        "stun_dur" : 2
+    },{
+        "type" : "technique",
+        "id" : "tec_krav_maga_rapid",
+        "name" : "quick punch",
+        "min_unarmed" : 2,
+        "unarmed_allowed" : true,
+        "messages" : [
+            "You quickly punch %s",
+            "<npcname> quickly punches %s"
+        ],
+        "mult_bonuses" : [
+            ["movecost", 0.5],
+            ["damage", "bash", 0.66],
+            ["damage", "cut", 0.66],
+            ["damage", "stab", 0.66]
+        ]
+    },{
+        "type" : "technique",
+        "id" : "tec_krav_maga_feint",
+        "name" : "feint at",
+        "min_unarmed" : 2,
+        "unarmed_allowed" : true,
+        "defensive" : true,
+        "miss_recovery" : true,
+        "messages" : [
+            "You feint at %s",
+            "<npcname> feints at %s"
+        ]
+    },{
+        "type" : "technique",
+        "id" : "tec_krav_maga_precise",
+        "name" : "precise strike",
+        "min_unarmed" : 3,
+        "unarmed_allowed" : true,
+        "crit_tec" : true,
+        "messages" : [
+            "You jab %s",
+            "<npcname> jabs %s"
+        ],
+        "stun_dur" : 2
+    },{
+        "type" : "technique",
+        "id" : "tec_krav_maga_disarm",
+        "name" : "disarm",
+        "min_unarmed" : 3,
+        "unarmed_allowed" : true,
+        "disarms" : true,
+        "messages" : [
+            "You disarm %s",
+            "<npcname> disarms %s"
+        ]
+    },{
+        "type" : "technique",
+        "id" : "tec_krav_maga_grab",
+        "name" : "grab",
+        "min_unarmed" : 4,
+        "unarmed_allowed" : true,
+        "down_dur" : 1,
+        "messages" : [
+            "You grab %s",
+            "<npcname> grabs %s"
+        ]
+    },{
+        "type" : "technique",
+        "id" : "tec_krav_maga_break",
+        "name" : "grab break",
+        "min_unarmed" : 4,
+        "unarmed_allowed" : true,
+        "melee_allowed" : true,
+        "defensive" : true,
+        "grab_break" : true
+    },{
+        "type" : "technique",
+        "id" : "tec_ninjutsu_precise",
+        "name" : "surprise attack",
+        "min_unarmed" : 3,
+        "min_melee" : 3,
+        "unarmed_allowed" : true,
+        "melee_allowed" : true,
+        "crit_tec" : true,
+        "messages" : [
+            "You surprise attack %s",
+            "<npcname> surprise attacks %s"
+        ],
+        "stun_dur" : 2,
+        "mult_bonuses" : [
+            ["damage", "bash", 1.4],
+            ["damage", "cut", 2]
+        ]
+    },{
+        "type" : "technique",
+        "id" : "tec_taekwondo_precise",
+        "name" : "axe-kick",
+        "min_unarmed" : 2,
+        "unarmed_allowed" : true,
+        "crit_tec" : true,
+        "stun_dur" : 2,
+        "messages" : [
+            "You axe-kick %s",
+            "<npcname> axe-kicks %s"
+        ]
+    },{
+        "type" : "technique",
+        "id" : "tec_taekwondo_push",
+        "name" : "side kick",
+        "min_unarmed":3,
+        "unarmed_allowed" : true,
+        "messages" : [
+            "You side-kick %s",
+            "<npcname> side-kicks %s"
+        ],
+        "stun_dur" : 1,
+        "knockback_dist" : 1
+    },{
+        "type" : "technique",
+        "id" : "tec_taekwondo_sweep",
+        "name" : "sweep kick",
+        "min_unarmed" : 4,
+        "unarmed_allowed" : true,
+        "messages" : [
+            "You sweep-kick %s",
+            "<npcname> sweep-kicks %s"
+        ],
+        "down_dur" : 2
+    },{
+        "type" : "technique",
+        "id" : "tec_biojutsu_counter",
+        "name" : "biojutsu counter",
+        "min_melee" : 4,
+        "unarmed_allowed" : true,
+        "block_counter": true,
+        "mult_bonuses" : [["movecost", 0.0]],
+        "messages" : [
+            "You block and counter-attack %s",
+            "<npcname> blocks and counter-attacks %s"
+        ]
+    },{
+        "type" : "technique",
+        "id" : "tec_biojutsu_rapid_unarmed",
+        "name" : "quick punch",
+        "min_melee" : 0,
+        "unarmed_allowed" : true,
+        "messages" : [
+            "You quickly punch %s",
+            "<npcname> quickly punches %s"
+        ],
+        "mult_bonuses" : [
+            ["movecost", 0.5],
+            ["damage", "bash", 0.66],
+            ["damage", "cut", 0.66],
+            ["damage", "stab", 0.66]
+        ]
+    },{
+        "type" : "technique",
+        "id" : "tec_biojutsu_rapid_armed",
+        "name" : "quick slash",
+        "min_melee" : 0,
+        "messages" : [
+            "You quickly slash %s",
+            "<npcname> quickly slashes %s"
+        ],
+        "mult_bonuses" : [
+            ["movecost", 0.5],
+            ["damage", "bash", 0.66],
+            ["damage", "cut", 0.66],
+            ["damage", "stab", 0.66]
+        ]
+    },{
+        "type" : "technique",
+        "id" : "tec_biojutsu_impale",
+        "name" : "biojutsu impale",
+        "min_melee" : 3,
+        "crit_tec" : true,
+        "mult_bonuses" : [
+            ["damage", "bash", 1.5],
+            ["damage", "cut", 1.5]
+        ],
+        "messages" : [
+            "You brutally impale %s",
+            "<npcname> brutally impales %s"
+        ],
+        "stun_dur" : 1
+    },{
+        "type" : "technique",
+        "id" : "tec_biojutsu_sweep",
+        "name" : "sweep kick",
+        "min_melee" : 3,
+        "unarmed_allowed" : true,
+        "messages" : [
+            "You sweep-kick %s",
+            "<npcname> sweep-kicks %s"
+        ],
+        "down_dur" : 2
+    },{
+        "type" : "technique",
+        "id" : "tec_biojutsu_wide",
+        "min_melee" : 5,
+        "crit_tec" : true,
+        "name" : "wide strike",
+        "messages" : [
+            "You cleave through %s",
+            "<npcname> cleave through %s"
+        ],
+        "aoe" : "wide"
+    },{
+        "type" : "technique",
+        "id" : "tec_zuiquan_feint",
+        "name" : "Drunk feint",
+        "min_unarmed" : 3,
+        "unarmed_allowed" : true,
+        "defensive" : true,
+        "miss_recovery" : true,
+        "messages" : [
+            "You stumble and leer at %s",
+            "<npcname> stumbles and leers at %s"
+        ]
+    },{
+        "type" : "technique",
+        "id" : "tec_zuiquan_counter",
+        "name" : "Drunk counter",
+        "min_unarmed" : 4,
+        "unarmed_allowed" : true,
+        "dodge_counter" : true,
+        "mult_bonuses" : [
+            ["movecost", 0.0],
+            ["damage", "bash", 1.25]
+        ],
+        "messages" : [
+            "You lurch, and your wild swing hits %s",
+            "<npcname> lurches, and hits %s"
+        ]
+    },{
+        "type" : "technique",
+        "id" : "tec_fencing_lunge",
+        "name" : "Fencing lunge",
+        "min_melee" : 2,
+        "mult_bonuses" : [["movecost", 0.75]],
+        "weighting" : 2,
+        "messages" : [
+            "You lunge at %s",
+            "<npcname> lunges at %s"
+        ]
+    },{
+        "type" : "technique",
+        "id" : "tec_fencing_thrust",
+        "name" : "Fencing thrust",
+        "min_melee" : 1,
+        "mult_bonuses" : [
+            ["movecost", 0.9],
+            ["damage", "stab", 1.25]
+        ],
+        "weighting" : 2,
+        "messages" : [
+            "You thrust at %s",
+            "<npcname> thrust at %s"
+        ]
+    },{
+        "type" : "technique",
+        "id" : "tec_fencing_stop_thrust",
+        "name" : "Fencing stop thrust",
+        "min_melee" : 3,
+        "block_counter": true,
+        "mult_bonuses" : [
+            ["movecost", 0.0],
+            ["damage", "stab", 1.5]
+        ],
+        "stun_dur" : 1,
+        "messages" : [
+            "You deliver a perfect stop thrust to %s",
+            "<npcname> delivers a perfect stop thrust to %s"
+        ]
+    },{
+        "type" : "technique",
+        "id" : "tec_eskrima_round",
+        "name" : "Round strike",
+        "min_melee" : 4,
+        "mult_bonuses" : [["movecost", 0.6]],
+        "messages" : [
+            "You round strike %s",
+            "<npcname> round strikes %s"
+        ]
+    },{
+        "type" : "technique",
+        "id" : "tec_eskrima_fan",
+        "name" : "Fan strike",
+        "min_melee" : 2,
+        "mult_bonuses" : [["movecost", 0.75]],
+        "messages" : [
+            "You fan strike %s",
+            "<npcname> fan strikes %s"
+        ]
+    },{
+        "type" : "technique",
+        "id" : "tec_eskrima_snap",
+        "name" : "Snap strike",
+        "min_melee" : 0,
+        "mult_bonuses" : [["movecost", 0.8]],
+        "messages" : [
+            "You snap out at %s",
+            "<npcname> snaps quickly at %s"
+        ]
+    },{
+        "type" : "technique",
+        "id" : "tec_eskrima_combination",
+        "name" : "Combination strike",
+        "min_melee" : 2,
+        "mult_bonuses" : [
+            ["movecost", 0.8],
+            ["damage", "bash", 1.5],
+            ["damage", "cut", 1.5],
+            ["damage", "stab", 1.5]
+        ],
+        "req_buffs" : [
+            "eskrima_hit_buff"
+        ],
+        "messages" : [
+            "You combination strike %s",
+            "<npcname> combination strikes %s"
+        ]
+    },{
+        "type" : "technique",
+        "id" : "tec_eskrima_free",
+        "name" : "free strike",
+        "min_melee" : 4,
+        "mult_bonuses" : [["movecost", 0.0]],
+        "req_buffs" : [
+            "eskrima_hit_buff"
+        ],
+        "messages" : [
+            "You whip a free strike onto %s",
+            "<npcname> free strikes %s"
+        ]
+    },{
+        "type" : "technique",
+        "id" : "tec_eskrima_puno",
+        "name" : "puño strike",
+        "min_melee" : 3,
+        "min_bashing_damage": 2,
+        "mult_bonuses" : [
+            ["damage", "bash", 4.0],
+            ["damage", "cut", 0.0],
+            ["damage", "stab", 0.0]
+        ],
+        "crit_tec" : true,
+        "stun_dur" : 1,
+        "messages" : [
+            "You deliver a puño to %s",
+            "<npcname> haftstrikes %s"
+        ]
+    },{
+        "type" : "technique",
+        "id" : "tec_eskrima_kick",
+        "name" : "knee strike",
+        "min_unarmed" : 3,
+        "crit_tec" : true,
+        "down_dur" : 2,
+        "messages" : [
+            "You deliver a knee strike to %s",
+            "<npcname> knees %s"
+        ]
+    },{
+        "type" : "technique",
+        "id" : "tec_silat_hamstring",
+        "name" : "hamstring",
+        "min_melee" : 2,
+        "crit_tec" : true,
+        "down_dur" : 3,
+        "messages" : [
+            "You ground %s with a low blow",
+            "<npcname> grounds %s with a low blow"
+        ]
+    },{
+        "type" : "technique",
+        "id" : "tec_silat_precise",
+        "name" : "Vicious Precision",
+        "min_melee" : 4,
+        "crit_tec" : true,
+        "mult_bonuses" : [
+            ["damage", "bash", 1.5],
+            ["damage", "cut", 1.5],
+            ["damage", "stab", 1.5]
+        ],
+        "messages" : [
+            "You viciously wound %s",
+            "<npcname> viciously wounds %s"
+        ]
+    },{
+        "type" : "technique",
+        "id" : "tec_silat_brutal",
+        "name" : "Silat Brutality",
+        "min_melee" : 3,
+        "crit_tec" : true,
+        "stun_dur" : 1,
+        "knockback_dist" : 1,
+        "messages" : [
+            "You send %s reeling backwards",
+            "<npcname> sends %s reeling"
+        ]
+    },{
+        "type" : "technique",
+        "id" : "tec_silat_dirty",
+        "name" : "Dirty Hit",
+        "min_melee" : 1,
+        "crit_tec" : true,
+        "stun_dur" : 2,
+        "req_buffs" : [
+            "silat_dodge_buff"
+        ],
+        "messages" : [
+            "You hit %s with a dirty blow",
+            "<npcname> delivers a dirty blow to %s"
+        ]
+    },{
+        "type" : "technique",
+        "id" : "tec_venom_snake_feint",
+        "name" : "Viper Hiss",
+        "unarmed_allowed" : true,
+        "melee_allowed" : true,
+        "defensive" : true,
+        "miss_recovery" : true,
+        "messages" : [
+            "You hiss threateningly at %s",
+            "<npcname> hisses threateningly at %s"
+        ]
+    },{
+        "type" : "technique",
+        "id" : "tec_venom_snake_rapid",
+        "name" : "Viper Fist",
+        "min_unarmed" : 3,
+        "unarmed_allowed" : true,
+        "mult_bonuses" : [
+            ["movecost", 0.5],
+            ["damage", "bash", 0.66],
+            ["damage", "cut", 0.66],
+            ["damage", "stab", 0.66]
+        ],
+        "messages" : [
+            "You quickly chop %s",
+            "<npcname> quickly chops %s"
+        ]
+    },{
+        "type" : "technique",
+        "id" : "tec_venom_snake_bite",
+        "name" : "Viper Bite",
+        "min_unarmed" : 0,
+        "unarmed_allowed" : true,
+        "req_buffs" : [
+            "venom_snake_combo_initiate"
+        ],
+        "messages" : [
+            "You Snakebite %s",
+            "<npcname> Snakebites %s"
+        ]
+    },{
+        "type" : "technique",
+        "id" : "tec_venom_snake_strike",
+        "name" : "Viper Strike",
+        "min_unarmed" : 0,
+        "unarmed_allowed" : true,
+        "req_buffs" : [
+            "venom_snake_combo_continue"
+        ],
+        "messages" : [
+            "You Viper Strike %s",
+            "<npcname> Viper Strikes %s"
+        ]
+    },{
+        "type" : "technique",
+        "id" : "tec_venom_snake_break",
+        "name" : "Viper Writhe",
+        "unarmed_allowed" : true,
+        "melee_allowed" : true,
+        "defensive" : true,
+        "grab_break" : true
+    },{
+        "type" : "technique",
+        "id" : "tec_scorpion_brutal",
+        "name" : "Stinger Strike",
+        "unarmed_allowed" : true,
+        "crit_tec" : true,
+        "stun_dur" : 3,
+        "knockback_dist" : 3,
+        "mult_bonuses" : [["damage", "bash", 2]],
+        "messages" : [
+            "Your Stinger Kick sends %s flying",
+            "<npcname>'s Stinger Kick sends %s flying"
+        ]
+    },{
+        "type" : "technique",
+        "id" : "tec_scorpion_precise",
+        "name" : "Pincer Strike",
+        "min_unarmed" : 4,
+        "unarmed_allowed" : true,
+        "mult_bonuses" : [["damage", "bash", 1.25]],
+        "messages" : [
+            "You punch %s with your Pincer Fist",
+            "<npcname> jabs %s with a Pincer Fist"
+        ],
+        "stun_dur" : 2
+    },{
+        "type" : "technique",
+        "id" : "tec_toad_grab",
+        "name" : "Toad's Tongue",
+        "min_unarmed" : 4,
+        "unarmed_allowed" : true,
+        "mult_bonuses" : [["movecost", 0.5]],
+        "down_dur" : 1,
+        "messages" : [
+            "You snatch and slug %s",
+            "<npcname> snatches and slug %s"
+        ]
+    },{
+        "type" : "technique",
+        "id" : "tec_centipede_rapid",
+        "name" : "Rapid Strike",
+        "min_unarmed" : 2,
+        "unarmed_allowed" : true,
+        "mult_bonuses" : [
+            ["movecost", 0.5],
+            ["damage", "bash", 0.66],
+            ["damage", "cut", 0.66],
+            ["damage", "stab", 0.66]
+        ],
+        "messages" : [
+            "You swiftly hit %s",
+            "<npcname> swiftly hits %s"
+        ]
+    },{
+        "type" : "technique",
+        "id" : "tec_snake_rapid",
+        "name" : "Snake Snap",
+        "min_unarmed" : 2,
+        "unarmed_allowed" : true,
+        "mult_bonuses" : [
+            ["movecost", 0.5],
+            ["damage", "bash", 0.66],
+            ["damage", "cut", 0.66],
+            ["damage", "stab", 0.66]
+        ],
+        "messages" : [
+            "You swiftly jab %s",
+            "<npcname> swiftly jabs %s"
+        ]
+    },{
+        "type" : "technique",
+        "id" : "tec_snake_feint",
+        "name" : "Snake Slide",
+        "min_unarmed" : 3,
+        "unarmed_allowed" : true,
+        "defensive" : true,
+        "miss_recovery" : true,
+        "messages" : [
+            "You make serpentine hand motions at %s",
+            "<npcname> makes serpentine hand motions at %s"
+        ]
+    },{
+        "type" : "technique",
+        "id" : "tec_snake_break",
+        "name" : "Snake Slither",
+        "min_unarmed" : 4,
+        "unarmed_allowed" : true,
+        "defensive" : true,
+        "grab_break" : true,
+        "messages" : [
+            "You slither free",
+            "<npcname> slithers free"
+        ]
+    },{
+        "type" : "technique",
+        "id" : "tec_snake_precise",
+        "name" : "Snake Strike",
+        "min_unarmed" : 4,
+        "unarmed_allowed" : true,
+        "crit_tec" : true,
+        "messages" : [
+            "You strike out at %s",
+            "<npcname> strikes out at %s"
+        ],
+        "stun_dur" : 2
+    },{
+        "type" : "technique",
+        "id" : "tec_tiger_grab",
+        "name" : "Tiger Takedown",
+        "min_unarmed" : 4,
+        "unarmed_allowed" : true,
+        "down_dur" : 1,
+        "messages" : [
+            "You grab and ground %s",
+            "<npcname> grabs and grounds %s"
+        ]
+    },{
+        "type" : "technique",
+        "id" : "tec_leopard_precise",
+        "name" : "Leopard Fist",
+        "min_unarmed" : 5,
+        "unarmed_allowed" : true,
+        "crit_tec" : true,
+        "messages" : [
+            "You strike out at %s with your Leopard Fist",
+            "<npcname> strikes out at %s with a Leopard Fist"
+        ],
+        "stun_dur" : 2
+    },{
+        "type" : "technique",
+        "id" : "tec_leopard_rapid",
+        "name" : "Leopard Swipe",
+        "min_unarmed" : 2,
+        "unarmed_allowed" : true,
+        "mult_bonuses" : [
+            ["movecost", 0.5],
+            ["damage", "bash", 0.66],
+            ["damage", "cut", 0.66],
+            ["damage", "stab", 0.66]
+        ],
+        "messages" : [
+            "You quickly swipe at %s",
+            "<npcname> quickly swipes at %s"
+        ]
+    },{
+        "type" : "technique",
+        "id" : "tec_leopard_counter",
+        "name" : "Leopard Foresight",
+        "min_unarmed" : 4,
+        "unarmed_allowed" : true,
+        "dodge_counter" : true,
+        "mult_bonuses" : [
+            ["movecost", 0.0],
+            ["damage", "bash", 1.5]
+        ],
+        "messages" : [
+            "You dodge the attack and swipe at %s's exposed flank",
+            "<npcname> dodges and catches %s exposed"
+        ]
+    },{
+        "type" : "technique",
+        "id" : "tec_dragon_grab",
+        "name" : "Dragon Snatch",
+        "min_unarmed" : 4,
+        "unarmed_allowed" : true,
+        "stun_dur" : 2,
+        "mult_bonuses" : [["damage", "bash", 1.2]],
+        "messages" : [
+            "You grab and knee %s",
+            "<npcname> grabs and knees %s"
+        ]
+    },{
+        "type" : "technique",
+        "id" : "tec_dragon_counter",
+        "name" : "Dragon's Vortex",
+        "min_unarmed" : 4,
+        "unarmed_allowed" : true,
+        "block_counter" : true,
+        "dodge_counter" : true,
+        "mult_bonuses" : [["movecost", 0.0]],
+        "stun_dur" : 2,
+        "messages" : [
+            "You catch the attack and send %s spinning",
+            "<npcname> catches and spins %s"
+        ]
+    },{
+        "type" : "technique",
+        "id" : "tec_dragon_sweep",
+        "name" : "Dragon Sweeper",
+        "min_unarmed" : 5,
+        "unarmed_allowed" : true,
+        "down_dur" : 2,
+        "messages" : [
+            "You low-roundhouse %s 's legs",
+            "<npcname> low-roundhouses %s 's legs"
+        ]
+    },{
+        "type" : "technique",
+        "id" : "tec_dragon_brutal",
+        "name" : "Dragon Strike",
+        "min_unarmed" : 6,
+        "unarmed_allowed" : true,
+        "crit_tec" : true,
+        "stun_dur" : 1,
+        "knockback_dist" : 1,
+        "messages" : [
+            "You send %s reeling with a Dragon Strike",
+            "<npcname> sends %s reeling with a Dragon Strike"
+        ]
+    },{
+        "type" : "technique",
+        "id" : "tec_crane_feint",
+        "name" : "Crane Wing",
+        "min_unarmed" : 2,
+        "unarmed_allowed" : true,
+        "defensive" : true,
+        "miss_recovery" : true,
+        "messages" : [
+            "You raise your arms intimidatingly",
+            "<npcname> performs the Crane Wing"
+        ]
+    },{
+        "type" : "technique",
+        "id" : "tec_crane_break",
+        "name" : "Crane Flap",
+        "min_unarmed" : 3,
+        "unarmed_allowed" : true,
+        "defensive" : true,
+        "grab_break" : true,
+        "messages" : [
+            "You swing your arms and break free",
+            "<npcname> flaps free"
+        ]
+    },{
+        "type" : "technique",
+        "id" : "tec_crane_precise",
+        "name" : "Crane Strike",
+        "min_unarmed" : 4,
+        "unarmed_allowed" : true,
+        "crit_tec" : true,
+        "messages" : [
+            "You hand-peck %s",
+            "<npcname> hand-pecks %s"
+        ],
+        "stun_dur" : 3
+    },{
+        "type" : "technique",
+        "id" : "tec_brawl_feint",
+        "name" : "Feint",
+        "min_unarmed" : 3,
+        "unarmed_allowed" : true,
+        "melee_allowed" : true,
+        "defensive" : true,
+        "miss_recovery" : true,
+        "messages" : [
+            "You fake a strike at %s",
+            "<npcname> feints at %s"
+        ]
+    },{
+        "type" : "technique",
+        "id" : "tec_brawl_power",
+        "name" : "Power Hit",
+        "min_unarmed" : 4,
+        "unarmed_allowed" : true,
+        "melee_allowed" : true,
+        "crit_tec" : true,
+        "stun_dur" : 1,
+        "knockback_dist" : 1,
+        "messages" : [
+            "You send %s reeling",
+            "<npcname> sends %s reeling"
+        ]
+    },{
+        "type" : "technique",
+        "id" : "tec_brawl_counter",
+        "name" : "Hit Them Back",
+        "min_unarmed" : 5,
+        "unarmed_allowed" : true,
+        "block_counter": true,
+        "mult_bonuses" : [["movecost", 0.0]],
+        "messages" : [
+            "You catch %s's attack, and hit back",
+            "<npcname> catches %s, and counters"
+        ]
+    },{
+        "type" : "technique",
+        "id" : "tec_brawl_trip",
+        "name" : "Trip",
+        "min_unarmed" : 5,
+        "unarmed_allowed" : true,
+        "down_dur" : 2,
+        "messages" : [
+            "You trip %s",
+            "<npcname> trips %s"
+        ]
+    },{
+        "type" : "technique",
+        "id" : "niten_water_cut",
+        "name" : "Flowing Water Cut",
+        "min_melee" : 4,
+        "mult_bonuses" : [
+            ["movecost", 1.75],
+            ["damage", "bash", 2.0],
+            ["damage", "cut", 2.0]
+        ],
+        "messages" : [
+            "You strike %s with the slow power of flowing water",
+            "<npcname> strikes %s with the slow power of flowing water"
+        ]
+    },{
+       "type" : "technique",
+      "id" : "niten_red_leaf",
+      "name" : "Red Leaf's Cut",
+      "min_melee" : 5,
+      "down_dur" : 2,
+        "messages" : [
+          "Your strike knocks %s off balance",
+          "<npcname>'s strike knocks %s off balance"
+      ]
+   },{
+        "type" : "technique",
+        "id" : "niten_stone_cut",
+        "name" : "Fire and Stone's Cut",
+        "min_melee" : 6,
+        "crit_tec" : true,
+        "mult_bonuses" : [
+            ["damage", "bash", 1.5],
+            ["damage", "cut", 1.5]
+        ],
+        "messages" : [
+            "You stun %s with the force of the blow",
+            "<npcname> stuns %s with the force of the blow"
+        ],
+        "stun_dur" : 2
+   },{
+        "type" : "technique",
+        "id" : "niten_timing_attack",
+        "name" : "In-One Timing",
+        "min_melee" : 5,
+        "req_buffs" : [
+            "niten_set-up"
+        ],
+        "messages" : [
+            "You strike at %s's weaknesses",
+            "<npcname> strikes %s's weaknesses"
+        ],
+        "//" : "Damage bonus plus Quick is severely powerful--generi-Quick takes a damage nerf.",
+        "mult_bonuses" : [
+            ["movecost", 0.5],
+            ["damage", "bash", 1.5],
+            ["damage", "cut", 1.5]
+        ],
+        "//" : "Minimum effective time for a status in combat is two turns, as you have one deducted on the same turn its applied.",
+        "stun_dur" : 2
+   },{
+       "type" : "technique",
+      "id" : "niten_feint",
+      "name" : "feint at",
+      "melee_allowed" : true,
+      "min_melee" : 2,
+      "defensive" : true,
+      "miss_recovery" : true,
+      "mult_bonuses" : [["movecost", 0.8]],
+      "messages" : [
+          "You feint at %s",
+          "<npcname> feints at %s"
+        ]
+    },{
+        "type" : "technique",
+        "id" : "tec_debug_slow",
+        "name" : "slow strike",
+        "unarmed_allowed" : true,
+        "strictly_unarmed" : true,
+        "min_unarmed" : 3,
+        "mult_bonuses" : [
+            ["damage", "bash", 3.0],
+            ["damage", "bash", "str", 0.1]
+        ],
+        "flat_bonuses" : [
+            ["movecost", 100],
+            ["movecost", "str", 10]
+        ],
+        "messages" : [
+            "You slowly strike %s",
+            "<npcname> slowly strikes %s"
+        ]
+    },{
+        "type" : "technique",
+        "id" : "tec_debug_arpen",
+        "name" : "phasing strike",
+        "unarmed_allowed" : true,
+        "melee_allowed" : true,
+        "min_melee" : 3,
+        "mult_bonuses" : [
+            ["damage", "bash", 0.2],
+            ["damage", "cut", 0.2],
+            ["damage", "stab", 0.2],
+            ["movecost", 0.3]
+        ],
+        "flat_bonuses" : [
+            ["arpen", "bash", 10],
+            ["arpen", "bash", "per", 1]
+        ],
+        "crit_tec" : true,
+        "messages" : [
+            "You phase-strike %s",
+            "<npcname> phase-strikes %s"
+        ]
+    },{
+        "type" : "technique",
+        "id" : "tec_sojutsu_push",
+        "name" : "Push",
+        "min_melee" : 1,
+        "mult_bonuses" : [
+            ["movecost", 0.0],
+            ["damage", "bash", 0.5],
+            ["damage", "cut", 0.5],
+            ["damage", "stab", 0.5]
+        ],
+        "unarmed_allowed" : false,
+        "block_counter": true,
+        "knockback_dist" : 1,
+        "messages" : [
+            "You push %s away",
+            "<npcname> pushes %s away"
+        ]
+    },{
+        "type" : "technique",
+        "id" : "tec_sojutsu_trip",
+        "name" : "Trip",
+        "min_melee" : 2,
+        "unarmed_allowed" : false,
+        "down_dur" : 2,
+        "messages" : [
+            "You deftly trip %s",
+            "<npcname> deftly trips %s"
+        ]
+    },{
+        "type" : "technique",
+        "id" : "tec_sojutsu_skewer",
+        "name" : "Skewer",
+        "min_melee" : 4,
+        "mult_bonuses" : [
+            ["damage", "bash", 0.0],
+            ["damage", "cut", 1.5],
+            ["damage", "stab", 1.5]
+        ],
+        "unarmed_allowed" : false,
+        "crit_tec" : true,
+        "knockback_dist" : 1,
+        "stun_dur" : 2,
+        "messages" : [
+            "You brutally skewer %s",
+            "<npcname> brutally skewers %s"
+        ]
+    }
+]


### PR DESCRIPTION
Reworks judo and capoeira, slightly modifies the animal styles and zui quan, obsoletes the five deadly venoms.

<!--
### How to use
Martial arts changes work fine on existing saves, five deadly venom files are left ingame, the trait is only made unselectable at start.
#### Summary
Martial arts rebalance
#### Purpose of change
After some discussion on discord, people were on agreement that the martial arts balance was all over the place, so i tackled it and made some changes.

Judo now gets an attack speed buff on hit but does less damage, while retaining his throwing/stunning/downing techniques, making the style good for retreating / stunlocking.

Capoeira now is built on strong area of effect attacks. Attacks deal high damage but you need to build momentum for 3 turns by moving.

Zui Quan changed so it adds 3 dodges on hit instead of 100, and made it's intelligence scaling only stack once, not twice, which made it the highest scaling martial art by almost a factor of two. It still has one of the strongest counter attacks of unarmed.

The animal styles are changed so they increase scaling in one stat, but slightly reduce strength scaling. These are still great alternatives for non brawny characters. Tiger style receives -5 bash damage, so it's strength scaling is only a net advantage at strength levels above 6. this bring it closer to being in line with muay thai.

The venom mob styles have been obsoleted by making them unselectable as a starting trait. their balance is all over the place, the lizard style is nonfunctional, and they're mostly a weird pop culture reference. (see https://www.youtube.com/watch?v=znPXlUgcMWA)
If someone is up to it they can be properly obsoleted and added back in as a mod. 